### PR TITLE
Serial output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LD=ld.lld
 LDFLAGS=-T arch/$(ARCH)/linker.ld
 
 OUTDIR=arch/$(ARCH)/build
-STEPS=arch/$(ARCH)/Micos.build kernel/Micos.build
+STEPS=arch/$(ARCH)/Micos.build kernel/Micos.build drivers/Micos.build
 TARGET=$(OUTDIR)/Micos
 
 CC=clang

--- a/arch/x86_64/kernel/Makefile
+++ b/arch/x86_64/kernel/Makefile
@@ -8,7 +8,7 @@ STEPS+=drivers/keyboard/keyboard_handler.o drivers/keyboard/init.o drivers/keybo
 STEPS+=interrupts/registry.o
 STEPS+=drivers/timer/receiver.o drivers/timer/initialiser.o
 STEPS+=drivers/pci/configuration_space.o
-STEPS+=drivers/serial/query.o
+STEPS+=drivers/serial/query.o drivers/serial/configuration.o drivers/serial/out.o
 
 Micos.build: $(STEPS)
 	$(LD) $(LDFLAGS) $^ -o $@

--- a/arch/x86_64/kernel/Makefile
+++ b/arch/x86_64/kernel/Makefile
@@ -8,6 +8,7 @@ STEPS+=drivers/keyboard/keyboard_handler.o drivers/keyboard/init.o drivers/keybo
 STEPS+=interrupts/registry.o
 STEPS+=drivers/timer/receiver.o drivers/timer/initialiser.o
 STEPS+=drivers/pci/configuration_space.o
+STEPS+=drivers/serial/query.o
 
 Micos.build: $(STEPS)
 	$(LD) $(LDFLAGS) $^ -o $@

--- a/arch/x86_64/kernel/drivers/serial/configuration.c
+++ b/arch/x86_64/kernel/drivers/serial/configuration.c
@@ -11,7 +11,7 @@ void configure_com1 ()
 {
     outb (0x80, COM1_IO_PORT + SERIAL_LINE_CONTROL); // going to set baudrate divisor
     outw (1, COM1_IO_PORT); // divisor
-    outb (3, COM1_IO_PORT); // 8 bit
+    outb (3, COM1_IO_PORT + SERIAL_LINE_CONTROL); // 8 bit
     outb (0xC7, COM1_IO_PORT + SERIAL_FIFO); // fifo
     outb (0x0F, COM1_IO_PORT + SERIAL_INTERRUPT); // set in normal operation mode
 }

--- a/arch/x86_64/kernel/drivers/serial/configuration.c
+++ b/arch/x86_64/kernel/drivers/serial/configuration.c
@@ -1,0 +1,17 @@
+#include <drivers/serial/serial.h>
+#include <io.h>
+
+#define COM1_IO_PORT  0x3f8
+#define SERIAL_INTERRUPT_CONTROL 1
+#define SERIAL_LINE_CONTROL 3
+#define SERIAL_FIFO 2
+#define SERIAL_INTERRUPT 4
+
+void configure_com1 ()
+{
+    outb (0x80, COM1_IO_PORT + SERIAL_LINE_CONTROL); // going to set baudrate divisor
+    outw (1, COM1_IO_PORT); // divisor
+    outb (3, COM1_IO_PORT); // 8 bit
+    outb (0xC7, COM1_IO_PORT + SERIAL_FIFO); // fifo
+    outb (0x0F, COM1_IO_PORT + SERIAL_INTERRUPT); // set in normal operation mode
+}

--- a/arch/x86_64/kernel/drivers/serial/out.c
+++ b/arch/x86_64/kernel/drivers/serial/out.c
@@ -1,0 +1,6 @@
+#include <drivers/serial/serial.h>
+
+void set_serial_enable ()
+{
+    return;
+}

--- a/arch/x86_64/kernel/drivers/serial/out.c
+++ b/arch/x86_64/kernel/drivers/serial/out.c
@@ -1,6 +1,30 @@
 #include <drivers/serial/serial.h>
+#include <io.h>
+
+#define COM1_BASE_ADDRESS 0x3f8
+#define SERIAL_STATUS 5
+
+static int status = 0; // 0 = disabled, 0xFF = enabled
 
 void set_serial_enable ()
 {
-    return;
+    status = 0xFF;
+}
+
+int is_serial_ready_for_output ()
+{
+    return inb (COM1_BASE_ADDRESS + SERIAL_STATUS) & 0x20;
+}
+
+void write_to_serial (u8_t val)
+{
+    if (status) {
+        // serial connection is enabled
+        while (is_serial_ready_for_output () == 0) {io_delay ();}
+
+        outb (val, COM1_BASE_ADDRESS);
+        if (val == '\n') {
+            write_to_serial ('\r');
+        }
+    }
 }

--- a/arch/x86_64/kernel/drivers/serial/query.c
+++ b/arch/x86_64/kernel/drivers/serial/query.c
@@ -1,0 +1,28 @@
+#include <drivers/serial/serial.h>
+#include <io.h>
+
+#define COM1_BASE_REGISTER  0x3f8
+#define SERIAL_LINE_CONTROL  3
+#define SERIAL_SCRATCH_OFFSET  7
+
+int query_com1 ()
+{
+    u8_t orig_scratch = inb (COM1_BASE_REGISTER + SERIAL_SCRATCH_OFFSET);
+    u8_t new_scratch = orig_scratch ^ 0xEE;
+    // is the scratch register writable?
+    outb (new_scratch, COM1_BASE_REGISTER + SERIAL_SCRATCH_OFFSET);
+    io_delay ();
+    if (inb (COM1_BASE_REGISTER + SERIAL_SCRATCH_OFFSET) ^ orig_scratch) {
+        outb (orig_scratch, COM1_BASE_REGISTER + SERIAL_SCRATCH_OFFSET);
+        u8_t orig_line_control = inb (COM1_BASE_REGISTER + SERIAL_LINE_CONTROL);
+        u8_t new_line_control = orig_line_control ^ 0x80; // flip the DLAB bit
+        u16_t orig_divisor_register = inw (COM1_BASE_REGISTER);
+        // does flipping the DLAB change the value of the divisor register?
+        outb (new_line_control, COM1_BASE_REGISTER + SERIAL_LINE_CONTROL);
+        if (inw (COM1_BASE_REGISTER) ^ orig_divisor_register) {
+            outb (orig_line_control, COM1_BASE_REGISTER + SERIAL_LINE_CONTROL);
+            return 1; // probably does exist
+        }
+    }
+    return 0; // no com port
+}

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -1,0 +1,10 @@
+STEPS:=serial/init/main.o
+
+Micos.build: $(STEPS)
+	$(LD) $(LDFLAGS) $^ -o $@
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $^ -o $@
+
+clean:
+	rm $(STEPS)

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -4,6 +4,7 @@ Micos.build: $(STEPS)
 	$(LD) $(LDFLAGS) $^ -o $@
 
 %.o: %.c
+	echo "$(CC) $(BASEDIR)/$@"
 	$(CC) $(CFLAGS) -c $^ -o $@
 
 clean:

--- a/drivers/serial/init/main.c
+++ b/drivers/serial/init/main.c
@@ -1,0 +1,16 @@
+#include <drivers/serial/serial.h>
+#include <drivers/init.h>
+
+void serial_init (void);
+
+static DRIVER serial_driver = {
+    .init = serial_init,
+    .priority = 0
+};
+
+void serial_init (void)
+{
+    if (query_com1 ()) {
+        return;
+    }
+}

--- a/drivers/serial/init/main.c
+++ b/drivers/serial/init/main.c
@@ -11,6 +11,7 @@ static DRIVER serial_driver = {
 void serial_init (void)
 {
     if (query_com1 ()) {
-        return;
+        configure_com1 ();
+        set_serial_enable ();
     }
 }

--- a/drivers/serial/init/main.c
+++ b/drivers/serial/init/main.c
@@ -10,6 +10,7 @@ static DRIVER serial_driver = {
 
 void serial_init (void)
 {
+    serial_driver.init = 0;
     if (query_com1 ()) {
         configure_com1 ();
         set_serial_enable ();

--- a/include/drivers/serial/serial.h
+++ b/include/drivers/serial/serial.h
@@ -1,9 +1,13 @@
 #ifndef _DRIVERS_SERIAL_SERIAL_H
 #define _DRIVERS_SERIAL_SERIAL_H
 
+#include <stdint.h>
+
 int query_com1 ();
 void configure_com1 ();
 
 void set_serial_enable ();
+
+void write_to_serial (u8_t val);
 
 #endif

--- a/include/drivers/serial/serial.h
+++ b/include/drivers/serial/serial.h
@@ -2,5 +2,8 @@
 #define _DRIVERS_SERIAL_SERIAL_H
 
 int query_com1 ();
+void configure_com1 ();
+
+void set_serial_enable ();
 
 #endif

--- a/include/drivers/serial/serial.h
+++ b/include/drivers/serial/serial.h
@@ -1,0 +1,6 @@
+#ifndef _DRIVERS_SERIAL_SERIAL_H
+#define _DRIVERS_SERIAL_SERIAL_H
+
+int query_com1 ();
+
+#endif

--- a/kernel/stdio/conout.c
+++ b/kernel/stdio/conout.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <drivers/serial/serial.h>
 
 #define DEFAULT_CONSOLE_MODE  STDOUT
 
@@ -6,6 +7,7 @@ int puts (char * str)
 {
     do {
         vga_print_char (* str, DEFAULT_CONSOLE_MODE);
+        write_to_serial (* str);
     }while (* (++str));
     vga_print_char ('\n', DEFAULT_CONSOLE_MODE);
     return 0;
@@ -13,6 +15,7 @@ int puts (char * str)
 int putchar (char c)
 {
     vga_print_char (c, DEFAULT_CONSOLE_MODE);
+    write_to_serial (c);
     return (int)c;
 }
 void putnum64 (u64_t num, int regex)


### PR DESCRIPTION
added support for a serial cable to be attached and have the operating system write to it (com 1 only). This will be useful if, for instance, there is a need to re-implement the rendering of characters on the screen.