### PR TITLE
Number print fix

### DIFF
--- a/kernel/stdio/conout.c
+++ b/kernel/stdio/conout.c
@@ -10,6 +10,7 @@ int puts (char * str)
         write_to_serial (* str);
     }while (* (++str));
     vga_print_char ('\n', DEFAULT_CONSOLE_MODE);
+    write_to_serial ('\n');
     return 0;
 }
 int putchar (char c)
@@ -18,6 +19,7 @@ int putchar (char c)
     write_to_serial (c);
     return (int)c;
 }
+
 void putnum64 (u64_t num, int regex)
 {
     char buffer [64];

--- a/kernel/stdio/conout.c
+++ b/kernel/stdio/conout.c
@@ -21,7 +21,7 @@ int putchar (char c)
 }
 
 static char number_table [] = {
-    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
 };
 
 void putnum64 (u64_t num, int regex)
@@ -29,12 +29,12 @@ void putnum64 (u64_t num, int regex)
     char buffer [64];
     int count;
     do {
-        buffer[count] = num % regex;
+        buffer[count] = number_table [num % regex];
         count ++;
         num /= regex;
     }while (num);
-    for (int i = 0; i < count; i ++) {
-        putchar (buffer [count - i - 1]);
+    for (; count > 0; count --) {
+        putchar (buffer [count - 1]);
     }
     putchar ('\n');
 }

--- a/kernel/stdio/conout.c
+++ b/kernel/stdio/conout.c
@@ -20,6 +20,10 @@ int putchar (char c)
     return (int)c;
 }
 
+static char number_table [] = {
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+};
+
 void putnum64 (u64_t num, int regex)
 {
     char buffer [64];


### PR DESCRIPTION
After the rewriting of putnum64, the numbers were not displayable characters. This was due to a lack of a conversion table between numbers and letters.