### PR TITLE
Frame buffer search

### DIFF
--- a/arch/x86_64/include/multiboot.h
+++ b/arch/x86_64/include/multiboot.h
@@ -1,0 +1,49 @@
+#ifndef _MULTIBOOT_H
+#define _MULTIBOOT_H  
+
+#include <stdint.h>
+
+#define MULTIBOOT_MBI_FRAME_BUFFER 8
+#define MBI_ALIGNMENT  8
+
+typedef struct __attribute__ ((__packed__)) {
+    u32_t size;
+    u32_t reserved;
+} mbi_begin_t;
+
+typedef struct __attribute__ ((__packed__)) {
+    u32_t type;
+    u32_t size;
+} mbi_tag_t;
+
+typedef struct __attribute__ ((__packed__)) {
+    u32_t type;
+    u32_t size;
+    u64_t address;
+    u32_t pitch;
+    u32_t width;
+    u32_t height;
+    u8_t pixel_bits;
+    u8_t frame_buffer_type;
+    u8_t reserved;
+    union {
+        struct __attribute__ ((__packed__)) {
+            u32_t number_of_colors;
+            struct __attribute__ ((__packed__)) {
+                u8_t red;
+                u8_t green;
+                u8_t blue;
+            } colors [0];
+        } indexed;
+        struct __attribute__ ((__packed__)) {
+            u8_t red_begin;
+            u8_t red_mask_size;
+            u8_t green_begin;
+            u8_t green_mask;
+            u8_t blue_begin;
+            u8_t blue_mask;
+        } rgb;
+    } color_descriptor;
+} mbi_frame_buffer_tag_t;
+
+#endif

--- a/arch/x86_64/init/finale.S
+++ b/arch/x86_64/init/finale.S
@@ -28,4 +28,6 @@ subq $stack, %rcx
 shrq $3, %rcx
 rep stosq
 
+callq scan_mbi
+
 jmp main /*into the main kernel code*/

--- a/arch/x86_64/init/multiboot.S
+++ b/arch/x86_64/init/multiboot.S
@@ -27,5 +27,6 @@ movl %ebx, 0 (%ecx)
 ret
 
 .section .init.data, "aw"
+.globl multiboot_data_ptr
 multiboot_data_ptr:
-.long 0 /*pointer to multiboot information structure*/
+.quad 0 /*pointer to multiboot information structure*/

--- a/arch/x86_64/kernel/Makefile
+++ b/arch/x86_64/kernel/Makefile
@@ -9,6 +9,7 @@ STEPS+=interrupts/registry.o
 STEPS+=drivers/timer/receiver.o drivers/timer/initialiser.o
 STEPS+=drivers/pci/configuration_space.o
 STEPS+=drivers/serial/query.o drivers/serial/configuration.o drivers/serial/out.o
+STEPS+=multiboot/mbi.o
 
 Micos.build: $(STEPS)
 	$(LD) $(LDFLAGS) $^ -o $@

--- a/arch/x86_64/kernel/multiboot/mbi.c
+++ b/arch/x86_64/kernel/multiboot/mbi.c
@@ -1,0 +1,1 @@
+#include <multiboot.h>

--- a/arch/x86_64/kernel/multiboot/mbi.c
+++ b/arch/x86_64/kernel/multiboot/mbi.c
@@ -1,1 +1,24 @@
 #include <multiboot.h>
+#include <frame_buffer.h>
+
+static frame_buffer_info_t frame_buffer;
+
+frame_buffer_info_t get_frame_buffer ()
+{
+    return frame_buffer;
+}
+
+extern u64_t multiboot_data_ptr;
+
+void scan_mbi ()
+{
+    u64_t mbi_ptr = multiboot_data_ptr + 8; /*first tag*/
+    while (((mbi_tag_t *)mbi_ptr)-> type) {
+        multiboot_tag_t tag = * ((mbi_tag_t *)mbi_ptr);
+        process_tag (tag);
+        mbi_ptr += ((tag->size + MBI_ALIGNMENT - 1) / 8) * 8;
+    }
+}
+void process_tag (mbi_tag_t tag) {
+    return;
+}

--- a/arch/x86_64/kernel/multiboot/mbi.c
+++ b/arch/x86_64/kernel/multiboot/mbi.c
@@ -10,21 +10,22 @@ frame_buffer_info_t get_frame_buffer ()
 
 extern u64_t multiboot_data_ptr;
 
+void process_tag (mbi_tag_t*  tag)
+{
+    if (tag->type == MULTIBOOT_MBI_FRAME_BUFFER) {
+        mbi_frame_buffer_tag_t * frame_buffer_ptr = (mbi_frame_buffer_tag_t *)tag;
+        frame_buffer.buffer = (frame_buffer_cell *)frame_buffer_ptr->address;
+        frame_buffer.width = frame_buffer_ptr->width;
+        frame_buffer.height = frame_buffer_ptr->height;
+    }
+}
+
 void scan_mbi ()
 {
     u64_t mbi_ptr = multiboot_data_ptr + 8; /*first tag*/
     while (((mbi_tag_t *)mbi_ptr)-> type) {
-        multiboot_tag_t tag = * ((mbi_tag_t *)mbi_ptr);
+        mbi_tag_t tag = * ((mbi_tag_t *)mbi_ptr);
         process_tag ((mbi_tag_t *)mbi_ptr);
-        mbi_ptr += ((tag->size + MBI_ALIGNMENT - 1) / 8) * 8;
-    }
-}
-
-void process_tag (mbi_tag_t*  tag) {
-    if (tag->type == MULTIBOOT_MBI_FRAME_BUFFER) {
-        mbi_frame_buffer_tag_t * frame_buffer_ptr = (mbi_frame_buffer_tag_t)tag;
-        frame_buffer.buffer = frame_buffer_ptr->address;
-        frame_buffer.width = frame_buffer_ptr->width;
-        frame_buffer.height = frame_buffer_ptr->height;
+        mbi_ptr += ((tag.size + MBI_ALIGNMENT - 1) / 8) * 8;
     }
 }

--- a/arch/x86_64/kernel/multiboot/mbi.c
+++ b/arch/x86_64/kernel/multiboot/mbi.c
@@ -15,10 +15,16 @@ void scan_mbi ()
     u64_t mbi_ptr = multiboot_data_ptr + 8; /*first tag*/
     while (((mbi_tag_t *)mbi_ptr)-> type) {
         multiboot_tag_t tag = * ((mbi_tag_t *)mbi_ptr);
-        process_tag (tag);
+        process_tag ((mbi_tag_t *)mbi_ptr);
         mbi_ptr += ((tag->size + MBI_ALIGNMENT - 1) / 8) * 8;
     }
 }
-void process_tag (mbi_tag_t tag) {
-    return;
+
+void process_tag (mbi_tag_t*  tag) {
+    if (tag->type == MULTIBOOT_MBI_FRAME_BUFFER) {
+        mbi_frame_buffer_tag_t * frame_buffer_ptr = (mbi_frame_buffer_tag_t)tag;
+        frame_buffer.buffer = frame_buffer_ptr->address;
+        frame_buffer.width = frame_buffer_ptr->width;
+        frame_buffer.height = frame_buffer_ptr->height;
+    }
 }

--- a/include/frame_buffer.h
+++ b/include/frame_buffer.h
@@ -1,0 +1,21 @@
+#ifndef _FRAME_BUFFER_H
+#define _FRAME_BUFFER_H  
+
+#include <stdint.h>
+
+typedef struct __attribute__ ((__packed__)) {
+    u8_t red;
+    u8_t green;
+    u8_t blue;
+    u8_t alpha;
+} frame_buffer_cell;
+
+typedef struct {
+    frame_buffer_cell * buffer;
+    u32_t width;
+    u32_t height;
+} frame_buffer_info_t;
+
+frame_buffer_info_t get_frame_buffer ();
+
+#endif


### PR DESCRIPTION
This change allows frame buffer information from the mbi (multiboot information) to be used later.