### PR TITLE
fixed a bug that was causing the long mode check to fail on most hardware

### DIFF
--- a/arch/x86_64/init/err.S
+++ b/arch/x86_64/init/err.S
@@ -19,6 +19,10 @@ movb $ERROR_COLOR, 1 (%edi)
 addl $2, %edi
 incl %esi
 jmp 1b
+movl $1000000, %ecx
 1:
-hlt
+decl %ecx
+jz 2f
 jmp 1b
+2:
+int $0x1 /*tripple fault the cpu*/

--- a/arch/x86_64/init/long.S
+++ b/arch/x86_64/init/long.S
@@ -10,12 +10,12 @@
 check_long_mode:
 movl $0x80000000, %eax
 cpuid /*highest extended feature parameter*/
-cmpl 0x80000001, %eax
+cmpl $0x80000001, %eax
 jb no_long_mode
 
 movl $0x80000001, %eax
 cpuid /*get extended features*/
-testl $1 << 29, %edx
+testl $(1 << 29), %edx
 jz no_long_mode
 ret
 no_long_mode:


### PR DESCRIPTION
The operating system has not been able to run under any hardware except qemu for its entire life. This was traced to a small typo in one of the assembly files.