### PR TITLE
Memcpy speed

### DIFF
--- a/arch/x86_64/kernel/memory/memops.S
+++ b/arch/x86_64/kernel/memory/memops.S
@@ -17,9 +17,13 @@ retq
 
 .globl memcpy
 memcpy:
-/*copy memory from rdi into rsi*/
-movq %rdx, %rcx
+/*copy memory from rsi into rdi*/
 pushq %rdi
-rep movsb
+movq %rdx, %rcx
+andq $7, %rdx /*remainder of division by 8*/
+shrq $3, %rcx /*divided by eight*/
+rep movsq /*store the quad words*/
+movq %rdx, %rcx
+rep movsb /*and the rest*/
 popq %rax
 retq

--- a/arch/x86_64/kernel/memory/memops.S
+++ b/arch/x86_64/kernel/memory/memops.S
@@ -9,9 +9,16 @@ memset:
 /*rdi contains the pointer, rsi contains the value to set and rdx contains the size of the block to set*/
 /*this corresponds to the c function declaration void memset (void * ptr, char c, size_t size);*/
 pushq %rdi
-movq %rdx, %rcx
-movq %rsi, %rax
-rep stosb
+movb %sil, %al
+movq $0x0101010101010101, %rcx
+movq %rdx, %r11
+mulq %rcx
+movq %r11, %rcx
+andq $7, %r11 /*remainder of division by 8*/
+shrq $3, %rcx /*divided by eight*/
+rep stosq /*store the quad words*/
+movq %r11, %rcx
+rep stosb /*and the rest*/
 popq %rax
 retq
 


### PR DESCRIPTION
Previously, the memcpy and memset functions copied the bytes one at a time (which is very slow on older/less powerfull hardware). In this feature, the memcpy and memset functions copy bytes eight at a time instead. This has created noticable improvements in console scrolling, which makes heavy use of both of these functions.