### PR TITLE
added -o2 flag to clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ AS=clang
 INCLUDEARGS=-I "$(CURDIR)/include" -I "$(CURDIR)/arch/$(ARCH)/include"
 
 AFLAGS=-target $(ARCH)-unknown-none-gnu -ffreestanding $(INCLUDEARGS)
-CFLAGS=-target $(ARCH)-unknown-none-gnu -ffreestanding -mno-red-zone -std=c11 $(INCLUDEARGS)
+CFLAGS=-target $(ARCH)-unknown-none-gnu -ffreestanding -mno-red-zone -o2 -std=c11 $(INCLUDEARGS)
 EXTERNALLDFLAGS=-relocatable
 
 $(include "arch/$(ARCH)/Make.properties")


### PR DESCRIPTION
There is still some slowness around old machines. This branch hoped to fix these problems by simply telling clang to use optimisations to increase speed. Unfortunately, the results of this were not quite as good as expected.