### PR TITLE
made the pci log print out hard drivesand their subclass

### DIFF
--- a/kernel/drivers/pci/pci_log.c
+++ b/kernel/drivers/pci/pci_log.c
@@ -9,19 +9,37 @@ static DRIVER pci_logger = {
     .priority = 2
 };
 
-static int print_pci_info(common_pci_header* header) {
-    puts ("pci device id:");
-    puthex64(header->device_id);
-    puts("vendor:");
-    puthex64(header->vendor_id);
-    puts ("Class:");
-    puthex64(header->class);
-    puts ("subclass:");
-    puthex64(header->subclass);
+static int handle_pci_device(common_pci_header* header) {
+    if (header->class == 0x1) {
+        puts ("Hard drive:");
+        switch (header->subclass) {
+            case 0x0:
+            puts ("Scsi!");
+            puthex64(header->vendor_id);
+            puthex64(header->device_id);
+            break;
+            case 0x1:
+            puts ("Ide!");
+            puthex64(header->vendor_id);
+            puthex64(header->device_id);
+            break;
+            case 0x6:
+            puts ("Sata!");
+            puthex64(header->vendor_id);
+            puthex64(header->device_id);
+            break;
+            default:
+            puts("Unknown...");
+            puthex64(header->vendor_id);
+            puthex64(header->device_id);
+            puthex64(header->subclass);
+            break;
+        }
+    }
     return 1;
 }
 
 void pci_log (void) {
     pci_logger.init = 0;
-    register_pci_driver(print_pci_info, 0);
+    register_pci_driver(handle_pci_device, 0);
 }


### PR DESCRIPTION
There are far too many pci devices on a real machine. This is why it was benifitial to filter them to just one type of device: hard drives. Since there is usually only one of these on a system, it seriously reduces clutter.