### PR TITLE
Map uncached

### DIFF
--- a/arch/x86_64/include/page_tables.h
+++ b/arch/x86_64/include/page_tables.h
@@ -10,7 +10,8 @@ typedef u64_t page_table_t [512] __attribute__ ((aligned (4096)));
 #define PAGE_PRESENT (1 << 0)
 #define PAGE_WRITABLE (1 << 1)
 #define PAGE_USER (1 << 2)
-/*we don't use the rest of the flags*/
+#define PAGE_WRITE_THROUGH_CACHE  (1 << 3)
+#define PAGE_CACHE_DISABLE  (1 << 4)
 
 void init_pml4 ();
 

--- a/arch/x86_64/kernel/paging/malloc/alloc.c
+++ b/arch/x86_64/kernel/paging/malloc/alloc.c
@@ -3,11 +3,26 @@
 
 void * malloc (size_t size)
 {
-    size = (size + 4096 + 8) / 4096 * 4096; // page aligned
+    size = (size + 4095 + 8) / 4096 * 4096; // page aligned
     void * ptr = reserve_block (size);
     u8_t * working_ptr = ptr;
     for (int i = 0; i < size; i+=4096){
         map_page ((u64_t)(working_ptr + i) >> 12, (u64_t)(working_ptr + i) >> 12, PAGE_PRESENT | PAGE_WRITABLE);
+    }
+    working_ptr = ptr;
+    * ((size_t *)working_ptr) = size;
+    working_ptr += sizeof (size_t);
+    ptr = working_ptr;
+    return ptr;
+}
+
+void* malloc_uncacheable(size_t size)
+{
+    size = (size + 4095 + 8) / 4096 * 4096; // page aligned
+    void * ptr = reserve_block (size);
+    u8_t * working_ptr = ptr;
+    for (int i = 0; i < size; i+=4096){
+        map_page ((u64_t)(working_ptr + i) >> 12, (u64_t)(working_ptr + i) >> 12, PAGE_PRESENT | PAGE_WRITABLE | PAGE_CACHE_DISABLE);
     }
     working_ptr = ptr;
     * ((size_t *)working_ptr) = size;

--- a/arch/x86_64/kernel/paging/mapping.c
+++ b/arch/x86_64/kernel/paging/mapping.c
@@ -14,6 +14,13 @@ page_table_entry_t * locate_page_table_entry (u64_t page)
     return ((page_table_entry_t *)PAGE_TABLE_VIRTUAL_ADDRESS (page_table,pdd,pdp)) + page_table_index;
 }
 
+void toggle_flags(u64_t page_index, page_table_entry_t flags)
+{
+    page_table_entry_t * destination_page_table = locate_page_table_entry (page_index);
+    *destination_page_table ^= flags;
+    invalidate_page_cache(page_index);
+}
+
 void map_page (u64_t frame, u64_t page_index, page_table_entry_t flags)
 {
     page_table_entry_t * destination_page_table = locate_page_table_entry (page_index);
@@ -38,4 +45,14 @@ void* map_physical_address (void * address, size_t size)
         map_page(frame_index + i, page_index + i, PAGE_PRESENT | PAGE_WRITABLE);
     }
     return (void*)(page_index * 4096);
+}
+void* map_physical_address_uncached(void* physical_address, size_t size) 
+{
+    void* ptr = map_physical_address(physical_address, size);
+    u64_t pages = (size + 4095) / 4096; // page aligned
+    u64_t page_index = ((u64_t)ptr) / 4096;
+    for (int i = 0; i < pages; i ++) {
+        toggle_flags(page_index + i, PAGE_CACHE_DISABLE);
+    }
+    return ptr;
 }

--- a/include/memory.h
+++ b/include/memory.h
@@ -6,4 +6,6 @@
 void* map_physical_address(void* physical_address, size_t size);
 void* map_physical_address_uncached(void* physical_address, size_t size);
 
+void* malloc_uncacheable(size_t size);
+
 #endif

--- a/include/memory.h
+++ b/include/memory.h
@@ -4,5 +4,6 @@
 #include <stdint.h>
 
 void* map_physical_address(void* physical_address, size_t size);
+void* map_physical_address_uncached(void* physical_address, size_t size);
 
 #endif

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -20,10 +20,6 @@ void main (void)
     putchar ('\n');
     puts ("completed initialisation");
     puts("Testing uncached malloc");
-    int* ptr = malloc_uncacheable(7*sizeof(int));
-    *ptr = 99;
-    putnum64(*ptr, 10);
-    free(ptr);
     loop:
     goto loop;
 }

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <memory.h>
 #include <drivers/init.h>
 
 void arch_init (void);
@@ -18,6 +19,11 @@ void main (void)
     __asm__ ("sti");
     putchar ('\n');
     puts ("completed initialisation");
+    puts("Testing uncached malloc");
+    int* ptr = malloc_uncacheable(7*sizeof(int));
+    *ptr = 99;
+    putnum64(*ptr, 10);
+    free(ptr);
     loop:
     goto loop;
 }

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -19,7 +19,6 @@ void main (void)
     __asm__ ("sti");
     putchar ('\n');
     puts ("completed initialisation");
-    puts("Testing uncached malloc");
     loop:
     goto loop;
 }


### PR DESCRIPTION
Added the feature of being able to map a block of memory (or malloc one, for that matter) which is not cached by the cpu. This will be useful for mapping hardware registers or creating buffers for dma.