### PR TITLE
Error screen

### DIFF
--- a/arch/x86_64/kernel/Makefile
+++ b/arch/x86_64/kernel/Makefile
@@ -10,6 +10,7 @@ STEPS+=drivers/timer/receiver.o drivers/timer/initialiser.o
 STEPS+=drivers/pci/configuration_space.o
 STEPS+=drivers/serial/query.o drivers/serial/configuration.o drivers/serial/out.o
 STEPS+=multiboot/mbi.o
+STEPS+=error/kill.o
 
 Micos.build: $(STEPS)
 	$(LD) $(LDFLAGS) $^ -o $@

--- a/arch/x86_64/kernel/error/kill.c
+++ b/arch/x86_64/kernel/error/kill.c
@@ -1,0 +1,6 @@
+#include <error.h>
+
+void kill_all()
+{
+    __asm__("cli");
+}

--- a/arch/x86_64/kernel/init/exceptions.S
+++ b/arch/x86_64/kernel/init/exceptions.S
@@ -4,28 +4,128 @@
 
 .text
 
-.globl standard_init_error_no_error_code
-standard_init_error_no_error_code:
-pushq $0
-jmp standard_init_error
-
-.globl standard_init_error
-standard_init_error:
-movq $abort_message, %rdi
-call puts
-1:
-hlt
-jmp 1b
-
-.globl standard_init_debug
-standard_init_debug:
+.globl divide_by_zero_handler
+divide_by_zero_handler:
+movq $divide_by_zero_message, %rdi
+callq fatal_error
+.globl debug_handler
+debug_handler:
 incq number_of_debug_interrupts
 iretq
+.globl non_maskable_interrupt_handler
+non_maskable_interrupt_handler:
+movq $non_maskable_interrupt_message, %rdi
+callq fatal_error
+.globl break_point_handler
+break_point_handler:
+movq $break_point_message, %rdi
+callq fatal_error
+.globl overflow_handler
+overflow_handler:
+movq $overflow_message, %rdi
+callq fatal_error
+.globl bound_range_exceeded_handler
+bound_range_exceeded_handler:
+movq $bound_range_exceeded_message, %rdi
+callq fatal_error
+.globl invalid_opcode_handler
+invalid_opcode_handler:
+movq $invalid_opcode_message, %rdi
+callq fatal_error
+.globl device_not_available_handler
+device_not_available_handler:
+movq $device_not_available_handler, %rdi
+callq fatal_error
+.globl double_fault_handler
+double_fault_handler:
+movq $double_fault_message, %rdi
+callq fatal_error
+.globl coprocessor_exception_handler
+coprocessor_exception_handler:
+movq $coprocessor_error_message, %rdi
+callq fatal_error
+.globl invalid_tss_handler
+invalid_tss_handler:
+movq $invalid_tss_message, %rdi
+callq fatal_error
+.globl unknown_segment_handler
+unknown_segment_handler:
+movq $unknown_segment_message, %rdi
+callq fatal_error
+.globl stack_fault_handler
+stack_fault_handler:
+movq $stack_fault_message, %rdi
+callq fatal_error
+.globl general_protection_fault_handler
+general_protection_fault_handler:
+movq $general_protection_fault_message, %rdi
+callq fatal_error
+.globl page_fault_handler
+page_fault_handler:
+movq $page_fault_message, %rdi
+callq fatal_error
+.globl floating_point_exception_handler
+floating_point_exception_handler:
+movq $floating_point_message, %rdi
+callq fatal_error
+.globl alignment_check_handler
+alignment_check_handler:
+movq $alignment_check_message, %rdi
+callq fatal_error
+.globl machine_check_handler
+machine_check_handler:
+movq $machine_check_message, %rdi
+callq fatal_error
+.globl virtualisation_exception_handler
+virtualisation_exception_handler:
+movq $virtualisation_exception_message, %rdi
+callq fatal_error
+.globl security_exception_handler
+security_exception_handler:
+movq $security_exception_message, %rdi
+callq fatal_error
+
 
 .data
 
-abort_message:
-.asciz "An error occured! Aborting"
+divide_by_zero_message:
+.asciz "Divide by 0"
+non_maskable_interrupt_message:
+.asciz "Non maskable interrupt"
+break_point_message:
+.asciz "Unexpected break point"
+overflow_message:
+.asciz "Overflow detected"
+bound_range_exceeded_message:
+.asciz "Bound range exceeded"
+invalid_opcode_message:
+.asciz "Invalid opcode"
+device_not_available_message:
+.asciz "Device not available"
+double_fault_message:
+.asciz "Unknown interrupt"
+coprocessor_error_message:
+.asciz "Coprocessor exception"
+invalid_tss_message:
+.asciz "Invalid tss"
+unknown_segment_message:
+.asciz "Unknown segment"
+stack_fault_message:
+.asciz "Stack fault"
+general_protection_fault_message:
+.asciz "General protection fault"
+page_fault_message:
+.asciz "Page fault"
+floating_point_message:
+.asciz "Floating point exception"
+alignment_check_message:
+.asciz "Alignment check"
+machine_check_message:
+.asciz "Machine check"
+virtualisation_exception_message:
+.asciz "Vm error"
+security_exception_message:
+.asciz "Security exception"
 
 .bss
 

--- a/arch/x86_64/kernel/init/main.c
+++ b/arch/x86_64/kernel/init/main.c
@@ -4,10 +4,26 @@
 
 extern u64_t number_of_debug_interrupts;
 
-void standard_init_error ();
-void standard_init_error_no_error_code ();
-
-void standard_init_debug ();
+void divide_by_zero_handler();
+void debug_handler();
+void non_maskable_interrupt_handler();
+void break_point_handler();
+void overflow_handler();
+void bound_range_exceeded_handler();
+void invalid_opcode_handler();
+void device_not_available_handler();
+void double_fault_handler();
+void coprocessor_exception_handler();
+void invalid_tss_handler();
+void unknown_segment_handler();
+void stack_fault_handler();
+void general_protection_fault_handler();
+void page_fault_handler();
+void floating_point_exception_handler();
+void alignment_check_handler();
+void machine_check_handler();
+void virtualisation_exception_handler();
+void security_exception_handler();
 
 static idt_entry idt [256];
 
@@ -15,27 +31,27 @@ static idt_ptr idt_pointer;
 
 void init_interrupts ()
 {
-    idt [INTERRUPT_DIVISION] = STANDARD_INTERRUPT ((u64_t)&standard_init_error_no_error_code);
-    idt [INTERRUPT_DEBUG] = STANDARD_INTERRUPT ((u64_t)&standard_init_debug);
-    idt [INTERRUPT_NMI] = STANDARD_INTERRUPT ((u64_t)&standard_init_error_no_error_code);
-    idt [INTERRUPT_BREAK] = STANDARD_INTERRUPT ((u64_t)&standard_init_error_no_error_code);
-    idt [INTERRUPT_OVERFLOW] = STANDARD_INTERRUPT ((u64_t)&standard_init_error_no_error_code);
-    idt [INTERRUPT_BOUND] = STANDARD_INTERRUPT ((u64_t)&standard_init_error_no_error_code);
-    idt [INTERRUPT_OPCODE] = STANDARD_INTERRUPT ((u64_t)&standard_init_error_no_error_code);
-    idt [INTERRUPT_DEVICE] = STANDARD_INTERRUPT ((u64_t)&standard_init_error_no_error_code);
-    idt [INTERRUPT_DOUBLE] = STANDARD_INTERRUPT ((u64_t)&standard_init_error);
-    idt [INTERRUPT_COPROCESSOR] = STANDARD_INTERRUPT ((u64_t)&standard_init_error_no_error_code);
-    idt [INTERRUPT_TSS] = STANDARD_INTERRUPT ((u64_t)&standard_init_error);
-    idt [INTERRUPT_SEGMENT] = STANDARD_INTERRUPT ((u64_t)&standard_init_error);
-    idt [INTERRUPT_STACK] = STANDARD_INTERRUPT ((u64_t)&standard_init_error);
-    idt [INTERRUPT_PROTECTION] = STANDARD_INTERRUPT ((u64_t)&standard_init_error);
-    idt [INTERRUPT_PAGE] = STANDARD_INTERRUPT ((u64_t)&standard_init_error);
-    idt [INTERRUPT_X87] = STANDARD_INTERRUPT ((u64_t)&standard_init_error_no_error_code);
-    idt [INTERRUPT_ALIGNMENT] = STANDARD_INTERRUPT ((u64_t)&standard_init_error);
-    idt [INTERRUPT_MACHINE] = STANDARD_INTERRUPT ((u64_t)&standard_init_error_no_error_code);
-    idt [INTERRUPT_SIMD] = STANDARD_INTERRUPT ((u64_t)&standard_init_error);
-    idt [INTERRUPT_VM] = STANDARD_INTERRUPT ((u64_t)&standard_init_error_no_error_code);
-    idt [INTERRUPT_SECURITY] = STANDARD_INTERRUPT ((u64_t)&standard_init_error);
+    idt [INTERRUPT_DIVISION] = STANDARD_INTERRUPT ((u64_t)&divide_by_zero_handler);
+    idt [INTERRUPT_DEBUG] = STANDARD_INTERRUPT ((u64_t)&debug_handler);
+    idt [INTERRUPT_NMI] = STANDARD_INTERRUPT ((u64_t)&non_maskable_interrupt_handler);
+    idt [INTERRUPT_BREAK] = STANDARD_INTERRUPT ((u64_t)&break_point_handler);
+    idt [INTERRUPT_OVERFLOW] = STANDARD_INTERRUPT ((u64_t)&overflow_handler);
+    idt [INTERRUPT_BOUND] = STANDARD_INTERRUPT ((u64_t)&bound_range_exceeded_handler);
+    idt [INTERRUPT_OPCODE] = STANDARD_INTERRUPT ((u64_t)&invalid_opcode_handler);
+    idt [INTERRUPT_DEVICE] = STANDARD_INTERRUPT ((u64_t)&device_not_available_handler);
+    idt [INTERRUPT_DOUBLE] = STANDARD_INTERRUPT ((u64_t)&double_fault_handler);
+    idt [INTERRUPT_COPROCESSOR] = STANDARD_INTERRUPT ((u64_t)&coprocessor_exception_handler);
+    idt [INTERRUPT_TSS] = STANDARD_INTERRUPT ((u64_t)&invalid_tss_handler);
+    idt [INTERRUPT_SEGMENT] = STANDARD_INTERRUPT ((u64_t)&unknown_segment_handler);
+    idt [INTERRUPT_STACK] = STANDARD_INTERRUPT ((u64_t)&stack_fault_handler);
+    idt [INTERRUPT_PROTECTION] = STANDARD_INTERRUPT ((u64_t)&general_protection_fault_handler);
+    idt [INTERRUPT_PAGE] = STANDARD_INTERRUPT ((u64_t)&page_fault_handler);
+    idt [INTERRUPT_X87] = STANDARD_INTERRUPT ((u64_t)&floating_point_exception_handler);
+    idt [INTERRUPT_ALIGNMENT] = STANDARD_INTERRUPT ((u64_t)&alignment_check_handler);
+    idt [INTERRUPT_MACHINE] = STANDARD_INTERRUPT ((u64_t)&machine_check_handler);
+    idt [INTERRUPT_SIMD] = STANDARD_INTERRUPT ((u64_t)&floating_point_exception_handler);
+    idt [INTERRUPT_VM] = STANDARD_INTERRUPT ((u64_t)&virtualisation_exception_handler);
+    idt [INTERRUPT_SECURITY] = STANDARD_INTERRUPT ((u64_t)&security_exception_handler);
     idt_pointer.limit = sizeof (idt) - 1;
     idt_pointer.ptr = (u64_t)&(idt[0]);
     __asm__ ("lidt %0" : : "m"(idt_pointer));

--- a/include/error.h
+++ b/include/error.h
@@ -1,0 +1,6 @@
+#ifndef _ERROR_H
+#define _ERROR_H  
+
+void fatal_error(const char* message);
+
+#endif

--- a/include/error.h
+++ b/include/error.h
@@ -3,4 +3,6 @@
 
 void fatal_error(const char* message);
 
+void kill_all();
+
 #endif

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -4,6 +4,7 @@ STEPS+=drivers/timer/handler.o
 STEPS+=drivers/pci/pci_init.o drivers/pci/pci_probe.o drivers/pci/pci_table.o drivers/pci/pci_log.o
 STEPS+=drivers/console/console.o
 STEPS+=stdio/conout.o
+STEPS+=error/error_screen.o
 
 Micos.build: $(STEPS)
 	$(LD) $(LDFLAGS) $^ -o $@

--- a/kernel/error/error_screen.c
+++ b/kernel/error/error_screen.c
@@ -17,6 +17,7 @@ static display_pixel character_foreground = {
 
 void fatal_error(const char* message)
 {
+    kill_all();
     video_mode vidmode = *get_video_mode();
     for (int i = 0; i < vidmode.width * vidmode.height; i ++) {
         * (vidmode.frame_buffer + i) = background;

--- a/kernel/error/error_screen.c
+++ b/kernel/error/error_screen.c
@@ -1,0 +1,5 @@
+#include <display.h>
+#include <error.h>
+
+void fatal_error(const char* message)
+{}

--- a/kernel/error/error_screen.c
+++ b/kernel/error/error_screen.c
@@ -1,5 +1,36 @@
 #include <display.h>
 #include <error.h>
+#include <fonts/renderer.h>
+
+static display_pixel background = {
+    .red = 0x10,
+    .green = 0x88,
+    .blue = 0x18,
+    .alpha = 0xFF
+};
+static display_pixel character_foreground = {
+    .red = 0x00,
+    .green = 0x00,
+    .blue = 0x00,
+    .alpha = 0x00
+};
 
 void fatal_error(const char* message)
-{}
+{
+    video_mode vidmode = *get_video_mode();
+    for (int i = 0; i < vidmode.width * vidmode.height; i ++) {
+        * (vidmode.frame_buffer + i) = background;
+    }
+    int columns = vidmode.width / get_character_width();
+    int rows = vidmode.height / get_character_height();
+    int start_x = columns / 2 - 3;
+    char error [6] = "Error!";
+    for (int i = 0; i < 6; i ++) {
+        render_character(start_x + i, 1, error[i], character_foreground, background);
+    }
+    int x = 0;
+    do {
+        render_character(x, 3, *message, character_foreground, background);
+        x ++;
+    }while (*(++message));
+}

--- a/kernel/error/error_screen.c
+++ b/kernel/error/error_screen.c
@@ -34,4 +34,6 @@ void fatal_error(const char* message)
         render_character(x, 3, *message, character_foreground, background);
         x ++;
     }while (*(++message));
+    loop:
+    goto loop;
 }

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -19,7 +19,6 @@ void main (void)
     __asm__ ("sti");
     putchar ('\n');
     puts ("completed initialisation");
-    fatal_error("Test");
     loop:
     goto loop;
 }

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -19,6 +19,7 @@ void main (void)
     __asm__ ("sti");
     putchar ('\n');
     puts ("completed initialisation");
+    fatal_error("Test");
     loop:
     goto loop;
 }


### PR DESCRIPTION
Added a new method of error handling. Instead of printing a small error message to the screen (which says nothing about the specific error) with a green error screen. This screen says the specific type of error, such as 'general protection fault' or 'floating point error'.