### PR TITLE
Frame buffer size variable

### DIFF
--- a/arch/x86_64/head/head.S
+++ b/arch/x86_64/head/head.S
@@ -22,8 +22,8 @@ information_request_end:
 .word 5 /*type*/
 .word 0 /*flags*/
 .long 20 /*size*/
-.long 1024 /*width*/
-.long 768 /*height*/
+.long 0 /*width, kernel doesn't mind*/
+.long 0 /*height, kernel doesn't mind*/
 .long 32 /*bits per pixel*/
 
 /*end tag*/

--- a/arch/x86_64/kernel/multiboot/mbi.c
+++ b/arch/x86_64/kernel/multiboot/mbi.c
@@ -18,9 +18,12 @@ void process_tag (mbi_tag_t*  tag)
 {
     if (tag->type == MULTIBOOT_MBI_FRAME_BUFFER) {
         mbi_frame_buffer_tag_t * frame_buffer_ptr = (mbi_frame_buffer_tag_t *)tag;
+        if (frame_buffer_ptr->pixel_bits == 32) {
         frame_buffer.buffer = (frame_buffer_cell *)frame_buffer_ptr->address;
         frame_buffer.width = frame_buffer_ptr->width;
         frame_buffer.height = frame_buffer_ptr->height;
+        frame_buffer.pitch = frame_buffer_ptr->pitch / 4;
+        }
     }
 }
 

--- a/drivers/display/display.c
+++ b/drivers/display/display.c
@@ -26,7 +26,9 @@ void display_init (void)
 }
 
 void write_pixel(int x, int y, display_pixel pixel) {
-    * (frame_buffer.buffer + (y * frame_buffer.width + x)) = pixel;
+    if (x >= 0 && x < frame_buffer.width && y >= 0 && y < frame_buffer.height) {
+        * (frame_buffer.buffer + (y * frame_buffer.width + x)) = pixel;
+    }
 }
 display_pixel get_pixel (int x, int y) {
     return * (frame_buffer.buffer + (y * frame_buffer.width + x));

--- a/drivers/display/display.c
+++ b/drivers/display/display.c
@@ -18,16 +18,17 @@ void display_init (void)
 {
     display_driver.init = 0;
     frame_buffer = *get_frame_buffer();
-    frame_buffer.buffer = map_physical_address(frame_buffer.buffer, frame_buffer.width * frame_buffer.height * sizeof (frame_buffer_cell));
+    frame_buffer.buffer = map_physical_address(frame_buffer.buffer, frame_buffer.width * frame_buffer.pitch * sizeof (frame_buffer_cell));
     initialise_font();
     vidmode.frame_buffer = frame_buffer.buffer;
     vidmode.width = frame_buffer.width;
     vidmode.height = frame_buffer.height;
+    vidmode.pitch = frame_buffer.pitch;
 }
 
 void write_pixel(int x, int y, display_pixel pixel) {
     if (x >= 0 && x < frame_buffer.width && y >= 0 && y < frame_buffer.height) {
-        * (frame_buffer.buffer + (y * frame_buffer.width + x)) = pixel;
+        * (frame_buffer.buffer + (y * frame_buffer.pitch + x)) = pixel;
     }
 }
 display_pixel get_pixel (int x, int y) {

--- a/include/display.h
+++ b/include/display.h
@@ -11,6 +11,7 @@ display_pixel read_pixel (int x, int y);
 typedef struct {
     int width;
     int height;
+    int pitch;
     display_pixel* frame_buffer;
 } video_mode;
 

--- a/include/frame_buffer.h
+++ b/include/frame_buffer.h
@@ -14,6 +14,7 @@ typedef struct {
     frame_buffer_cell * buffer;
     u32_t width;
     u32_t height;
+    u32_t pitch; // (in pixels, not bytes)
 } frame_buffer_info_t;
 
 frame_buffer_info_t* get_frame_buffer ();

--- a/kernel/drivers/console/console.c
+++ b/kernel/drivers/console/console.c
@@ -16,8 +16,8 @@ static void check_position_is_in_bounds () {
         current_y ++;
     }
     if (current_y >= lines) {
-        memcpy (vidmode.frame_buffer, vidmode.frame_buffer + vidmode.width * get_character_height(), (lines - 1) * get_character_height() * vidmode.width * sizeof (display_pixel));
-         memset(vidmode.frame_buffer + vidmode.width * get_character_height() * (lines - 1), 0x00, vidmode.width * get_character_height() * sizeof (display_pixel));
+        memcpy (vidmode.frame_buffer, vidmode.frame_buffer + vidmode.pitch * get_character_height(), (lines - 1) * get_character_height() * vidmode.pitch * sizeof (display_pixel));
+         memset(vidmode.frame_buffer + vidmode.pitch * get_character_height() * (lines - 1), 0x00, vidmode.pitch * get_character_height() * sizeof (display_pixel));
         current_y = lines - 1;
         current_x = 0;
     }

--- a/kernel/error/error_screen.c
+++ b/kernel/error/error_screen.c
@@ -3,9 +3,9 @@
 #include <fonts/renderer.h>
 
 static display_pixel background = {
-    .red = 0x10,
+    .red = 0x08,
     .green = 0x88,
-    .blue = 0x18,
+    .blue = 0x10,
     .alpha = 0xFF
 };
 static display_pixel character_foreground = {
@@ -19,8 +19,10 @@ void fatal_error(const char* message)
 {
     kill_all();
     video_mode vidmode = *get_video_mode();
-    for (int i = 0; i < vidmode.width * vidmode.height; i ++) {
-        * (vidmode.frame_buffer + i) = background;
+    for (int x = 0; x < vidmode.width; x ++) {
+        for (int y = 0; y < vidmode.height; y ++) {
+            * (vidmode.frame_buffer + y * vidmode.pitch + x) = background;
+        }
     }
     int columns = vidmode.width / get_character_width();
     int rows = vidmode.height / get_character_height();


### PR DESCRIPTION
Previously, Micos requested a frame buffer of 1024x768. On most modern monitors, however, the screen resolution is greater than this.
This change allows the boot loader to choose a frame buffer size to best fit the monitor.
This change also makes use of the pitch of the frame buffer, since this was causing bugs on some hardware.