### PR TITLE
Thread synchronisation

### DIFF
--- a/include/lock.h
+++ b/include/lock.h
@@ -1,0 +1,28 @@
+#ifndef _LOCK_H
+#define _LOCK_H  
+
+#include <stdint.h>
+#include <task/registry.h>
+
+typedef u32_t lock_t;
+
+static inline void synchronise(lock_t* lock) {
+    initial_lock_check:
+    if (!(*lock)) {
+        u32_t current_task_id = get_current_task_state()->id;
+        if (!(*lock)) {
+            *lock = current_task_id;
+            if (*lock == current_task_id) {
+                return;
+            }
+        }
+    }
+    while (*lock);
+    goto initial_lock_check;
+}
+
+static inline void free_lock(lock_t* lock) {
+    *lock = 0;
+}
+
+#endif

--- a/kernel/stdio/conout.c
+++ b/kernel/stdio/conout.c
@@ -1,23 +1,30 @@
 #include <stdio.h>
 #include <drivers/serial/serial.h>
 #include <console.h>
+#include <lock.h>
 
 #define DEFAULT_CONSOLE_MODE  STDOUT
 
+static lock_t console_lock;
+
 int puts (char * str)
 {
+    synchronise(&console_lock);
     do {
         console_write_char (* str);
         write_to_serial (* str);
     }while (* (++str));
     console_write_char ('\n');
     write_to_serial ('\n');
+    free_lock(&console_lock);
     return 0;
 }
 int putchar (char c)
 {
+    synchronise(&console_lock);
     console_write_char (c);
     write_to_serial (c);
+    free_lock(&console_lock);
     return (int)c;
 }
 
@@ -34,10 +41,14 @@ void putnum64 (u64_t num, int regex)
         count ++;
         num /= regex;
     }while (num);
+    synchronise(&console_lock);
     for (; count > 0; count --) {
-        putchar (buffer [count - 1]);
+        console_write_char(buffer [count]);
+        write_to_serial(buffer [count]);
     }
-    putchar ('\n');
+    console_write_char('\n');
+    write_to_serial('\n');
+    free_lock(&console_lock);
 }
 void puthex64 (u64_t num)
 {

--- a/kernel/task/registry.c
+++ b/kernel/task/registry.c
@@ -8,9 +8,13 @@ static int size = 1, capacity = NUMBER_OF_TASKS;
 
 static int current;
 
+static task_state default_task = {
+    .id = 0
+};
+
 task_state* get_current_task_state()
 {
-    return tasks [current];
+    return current ? tasks [current] : &default_task;
 }
 void register_task_state(task_state* task)
 {


### PR DESCRIPTION
This change adds support for synchronisation to prevent multiple threads from accessing the same functions as the same time. It uses a lock object in order to allow for synchronisation across multiple functions, for instance console output and memory allocation.