### PR TITLE
Failing threads

### DIFF
--- a/arch/x86_64/kernel/task/state.S
+++ b/arch/x86_64/kernel/task/state.S
@@ -66,5 +66,4 @@ movq 144 (%rbp), %rax
 movq %rax, %cr3 /*page table*/
 popq %rax
 popq %rbp
-movq $0xFF01FF01110F, %r15
 iretq /*set ss, rsp, rflags, cs and rip*/

--- a/arch/x86_64/kernel/task/state.S
+++ b/arch/x86_64/kernel/task/state.S
@@ -25,7 +25,7 @@ movq %rcx, 40 (%rbp) /*rcx*/
 movq %rdi, 48 (%rbp) /*rdi*/
 movq %rdx, 56 (%rbp) /*rdx*/
 movq %rsi, 64 (%rbp) /*rsi*/
-movq 32 (%rsp), %rax
+movq 24 (%rsp), %rax
 movq %rax, 72 (%rbp) /*rsp*/
 movq %r8, 80 (%rbp) /*r8*/
 movq %r9, 88 (%rbp) /*r9*/
@@ -66,4 +66,5 @@ movq 144 (%rbp), %rax
 movq %rax, %cr3 /*page table*/
 popq %rax
 popq %rbp
+movq $0xFF01FF01110F, %r15
 iretq /*set ss, rsp, rflags, cs and rip*/

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -5,18 +5,14 @@
 
 void arch_init (void);
 
-char s;
-
-char something () {
-    return s++;
-}
-
 void thread_start (void* arg)
 {
-    putchar(*((char*)arg));
-    loop:
-    * ((char*)arg) = something();
-    goto loop;
+    char* char_arg = (char*)arg;
+    for (unsigned int i = 0; ; i ++) {
+        if (i % 5000000 == 0) {
+            putchar (* char_arg + (i % 26));
+        }
+    }
 }
 
 void main (void)
@@ -29,10 +25,10 @@ void main (void)
     initialise_drivers (2);
     initialise_drivers (3);
     u32_t thread_id;
-    create_thread(&thread_id, thread_start, "1");
+    create_thread(&thread_id, thread_start, "a");
     puts ("Thread1:");
     putnum64(thread_id, 10);
-    create_thread(&thread_id, thread_start, "2");
+    create_thread(&thread_id, thread_start, "A");
     puts ("Thread 2:");
     putnum64(thread_id, 10);
     __asm__ ("sti");

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -5,10 +5,17 @@
 
 void arch_init (void);
 
+char s;
+
+char something () {
+    return s++;
+}
+
 void thread_start (void* arg)
 {
     putchar(*((char*)arg));
     loop:
+    * ((char*)arg) = something();
     goto loop;
 }
 

--- a/kernel/task/registry.c
+++ b/kernel/task/registry.c
@@ -27,5 +27,6 @@ task_state* get_next_task_state()
     if (++current >= size) {
         current = 1;
     }
+    tasks [current]->registers.r15 = 0x11111111F1F1F1F1;
     return tasks[current];
 }

--- a/kernel/task/registry.c
+++ b/kernel/task/registry.c
@@ -27,6 +27,5 @@ task_state* get_next_task_state()
     if (++current >= size) {
         current = 1;
     }
-    tasks [current]->registers.r15 = 0x11111111F1F1F1F1;
     return tasks[current];
 }


### PR DESCRIPTION
The new thread system in the kernel has always worked for the simple task of sitting in an infinite loop. If the thread tries to call other functions, however, it used to crash the kernel with a general protection fault, page fault or invalid opcode error. This fix removes the bug and adds a test function which proves its success.