### PR TITLE
Wait and notify

### DIFF
--- a/kernel/arch/x86_64/kernel/thread/thread.c
+++ b/kernel/arch/x86_64/kernel/thread/thread.c
@@ -5,7 +5,7 @@
 
 #define THREAD_STACK_SIZE 65536
 
-int create_thread (u32_t* id, void (*start)(void*), void* arg)
+int create_thread (thread_t* thread, void (*start)(void*), void* arg)
 {
     int8_t* stack = malloc(THREAD_STACK_SIZE);
     if (stack == 0) {
@@ -25,6 +25,6 @@ int create_thread (u32_t* id, void (*start)(void*), void* arg)
     task->registers.cr3 = cr3;
     task->registers.rdi = arg;
     register_task_state(task);
-    *id = task->id;
+    *thread = task->id;
     return 0;
 }

--- a/kernel/include/task/state.h
+++ b/kernel/include/task/state.h
@@ -6,7 +6,8 @@
 typedef struct __attribute__((__packed__)) {
     register_state registers; // Registers, different for each architecture
     u32_t id; // Task id
-    u8_t user: 1; // User mode task?
+    u8_t user; // User mode task?
+    u8_t wait, notify; // Wait and notify flags
 } task_state;
 
 #endif

--- a/kernel/include/thread.h
+++ b/kernel/include/thread.h
@@ -3,6 +3,13 @@
 
 #include <stdint.h>
 
-int create_thread(u32_t* id, void (*start)(void*), void* arg);
+typedef u32_t thread_t;
+
+int create_thread(thread_t* thread, void (*start)(void*), void* arg);
+
+// Waits until a call to notify () with the current thread id
+void wait ();
+
+void notify (thread_t thread);
 
 #endif

--- a/kernel/include/thread.h
+++ b/kernel/include/thread.h
@@ -12,4 +12,6 @@ void wait ();
 
 void notify (thread_t thread);
 
+thread_t current_thread();
+
 #endif

--- a/kernel/kernel/main.c
+++ b/kernel/kernel/main.c
@@ -24,7 +24,7 @@ void main (void)
     initialise_drivers (1);
     initialise_drivers (2);
     initialise_drivers (3);
-    u32_t thread_id;
+    thread_t thread_id;
     create_thread(&thread_id, thread_start, "a");
     puts ("Thread1:");
     putnum64(thread_id, 10);

--- a/kernel/kernel/main.c
+++ b/kernel/kernel/main.c
@@ -8,11 +8,11 @@ void arch_init (void);
 void thread_start (void* arg)
 {
     char* char_arg = (char*)arg;
-    for (unsigned int i = 0; ; i ++) {
-        if (i % 5000000 == 0) {
-            putchar (* char_arg + (i % 26));
-        }
-    }
+    loop:
+    putchar (*char_arg);
+    notify (current_thread() == 1 ? 2 : 1);
+    wait ();
+    goto loop;
 }
 
 void main (void)

--- a/kernel/kernel/task/registry.c
+++ b/kernel/kernel/task/registry.c
@@ -25,8 +25,17 @@ void register_task_state(task_state* task)
 }
 task_state* get_next_task_state()
 {
+    change_current:
     if (++current >= size) {
         current = 1;
+    }
+    if (tasks [current]->wait) {
+        if (tasks [current]->notify) {
+            tasks [current]->wait = 0;
+            tasks [current].notify = 0;
+        }else {
+            goto change_current;
+        }
     }
     return tasks[current];
 }
@@ -34,6 +43,7 @@ task_state* get_next_task_state()
 void wait ()
 {
     tasks [current]->wait = 1;
+    while (tasks [current]->wait);
 }
 
 void notify (thread_t thread)

--- a/kernel/kernel/task/registry.c
+++ b/kernel/kernel/task/registry.c
@@ -32,7 +32,7 @@ task_state* get_next_task_state()
     if (tasks [current]->wait) {
         if (tasks [current]->notify) {
             tasks [current]->wait = 0;
-            tasks [current].notify = 0;
+            tasks [current]->notify = 0;
         }else {
             goto change_current;
         }
@@ -49,4 +49,9 @@ void wait ()
 void notify (thread_t thread)
 {
     tasks [thread]->notify = 1;
+}
+
+thread_t current_thread ()
+{
+    return current;
 }

--- a/kernel/kernel/task/registry.c
+++ b/kernel/kernel/task/registry.c
@@ -1,4 +1,5 @@
 #include <task/registry.h>
+#include <thread.h>
 
 #define NUMBER_OF_TASKS  1024
 
@@ -28,4 +29,14 @@ task_state* get_next_task_state()
         current = 1;
     }
     return tasks[current];
+}
+
+void wait ()
+{
+    tasks [current]->wait = 1;
+}
+
+void notify (thread_t thread)
+{
+    tasks [thread]->notify = 1;
 }


### PR DESCRIPTION
This change adds two new functions: wait and notify. Wait stops the current task until it is notified by another task. Notify wakes up waiting tasks so they can continue running. The wait function stops the current task from using cpu time, so other tasks can run more efficiently.
This will be useful when implementing inter-process communication.