### PR TITLE
Use rtc timer for scheduler

### DIFF
--- a/kernel/arch/x86_64/kernel/drivers/pit/receiver.S
+++ b/kernel/arch/x86_64/kernel/drivers/pit/receiver.S
@@ -5,41 +5,9 @@
 .text
 
 .globl handle_timer_interrupt
-handle_timer_interrupt: /*Task switch (maybe)*/
-pushq %rbp
-movq %rsp, %rbp
-pushq 24 (%rbp) /*rflags*/
-pushq 32 (%rbp) /*rsp*/
-pushq 8 (%rbp) /*rip*/
-subq $8, %rsp
-
+handle_timer_interrupt: /*Not used for now*/
 pushq %rax
-pushq %rcx
-pushq %rdx
-pushq %rdi
-pushq %rsi
-pushq %r8
-pushq %r9
-pushq %r10
-pushq %r11
-callq get_current_task_state
-popq %r11
-popq %r10
-popq %r9
-popq %r8
-popq %rsi
-popq %rdi
-popq %rdx
-popq %rcx
-movq %rax, -32 (%rbp)
-popq %rax
-movq (%rbp), %rbp
-callq save_register_state
-
 movb $0x20, %al
 outb %al, $0x20
-sti
-
-callq get_next_task_state
-movq %rax, %rdi
-callq restore_register_state
+popq %rax
+iretq

--- a/kernel/arch/x86_64/kernel/drivers/rtc/timer/handler.S
+++ b/kernel/arch/x86_64/kernel/drivers/rtc/timer/handler.S
@@ -19,39 +19,14 @@ movq count, %rax
 incq %rax
 movq %rax, count
 cmpq $1024, %rax
-jb 1f
-pushq %rbx
-pushq %rcx
-pushq %rdi
-pushq %rdx
-pushq %rsi
-pushq %r8
-pushq %r9
-pushq %r10
-pushq %r11
-movq $msg, %rdi
-callq puts
-movq $0, count
-popq %r11
-popq %r10
-popq %r9
-popq %r8
-popq %rsi
-popq %rdx
-popq %rdi
-popq %rcx
-popq %rbx
-1:
 popq %rdx
 popq %rax
+jb 1f
+movq $0, count
+1:
 iretq
 
 .data
 
 count:
 .quad 0
-
-.rodata
-
-msg:
-.asciz "A second"

--- a/kernel/arch/x86_64/kernel/drivers/rtc/timer/handler.S
+++ b/kernel/arch/x86_64/kernel/drivers/rtc/timer/handler.S
@@ -18,7 +18,8 @@ inb $0x71, %al
 movq count, %rax
 incq %rax
 movq %rax, count
-cmpq $1024, %rax
+/*64 Hz*/
+cmpq $16, %rax
 popq %rdx
 popq %rax
 jb 1f

--- a/kernel/arch/x86_64/kernel/drivers/rtc/timer/handler.S
+++ b/kernel/arch/x86_64/kernel/drivers/rtc/timer/handler.S
@@ -12,19 +12,55 @@ movw $0xA0, %dx
 outb %al, %dx
 movb $0xC, %al
 outb %al, $0x70
-movb $10, %al
-outb %al, $0x80
 inb $0x71, %al
 movq count, %rax
 incq %rax
 movq %rax, count
 /*64 Hz*/
 cmpq $16, %rax
+jb 1f
 popq %rdx
 popq %rax
-jb 1f
 movq $0, count
+/*Task switch*/
+cli
+pushq %rbp
+movq %rsp, %rbp
+pushq 24 (%rbp) /*rflags*/
+pushq 32 (%rbp) /*rsp*/
+pushq 8 (%rbp) /*rip*/
+subq $8, %rsp
+
+pushq %rax
+pushq %rcx
+pushq %rdx
+pushq %rdi
+pushq %rsi
+pushq %r8
+pushq %r9
+pushq %r10
+pushq %r11
+callq get_current_task_state
+popq %r11
+popq %r10
+popq %r9
+popq %r8
+popq %rsi
+popq %rdi
+popq %rdx
+popq %rcx
+movq %rax, -32 (%rbp)
+popq %rax
+movq (%rbp), %rbp
+callq save_register_state
+
+callq get_next_task_state
+movq %rax, %rdi
+callq restore_register_state
+
 1:
+popq %rdx
+popq %rax
 iretq
 
 .data

--- a/kernel/arch/x86_64/kernel/drivers/rtc/timer/init.c
+++ b/kernel/arch/x86_64/kernel/drivers/rtc/timer/init.c
@@ -14,9 +14,11 @@ void rtc_timer_handler (void);
 void rtc_timer_init (void)
 {
     register_interrupt_handler(rtc_timer_handler, 0x38);
-    outb (0x8C, 0x70);
-    u8_t previous = inb (0x70);
-    outb (0x8b, 0x70);
+    outb (0x8B, 0x70);
+    u8_t previous = inb (0x71);
+    outb (0x8B, 0x70);
     outb (previous | 0x40, 0x71);
+    outb (0x8C, 0x70);
+    inb (0x71);  // Read status register C in case the chip is still waiting to send another interrupt
     rtc_timer_driver.init = 0;
 }

--- a/kernel/kernel/main.c
+++ b/kernel/kernel/main.c
@@ -9,6 +9,7 @@ void thread_start (void* arg)
 {
     char* char_arg = (char*)arg;
     loop:
+    putchar (*char_arg);
     notify (current_thread() == 1 ? 2 : 1);
     wait ();
     goto loop;


### PR DESCRIPTION
Previously, the scheduler was running on the pit with the default frequency (approximately 18.2Hz). The pit can be programmed to get very high frequencies (approximately 596591Hz). This could be useful for implementing function such as sleep.
This feature moves the scheduler to the rtc timer interrupt in order to free up the pit to be used for more useful tasks.