### PR TITLE
Get kernel time in nanoseconds

### DIFF
--- a/kernel/arch/x86_64/kernel/drivers/pit/initialiser.c
+++ b/kernel/arch/x86_64/kernel/drivers/pit/initialiser.c
@@ -1,5 +1,6 @@
 #include <drivers/init.h>
 #include <interrupts.h>
+#include <io.h>
 
 void handle_timer_interrupt (void);
 
@@ -13,5 +14,14 @@ static DRIVER timer_driver = {
 void timer_init (void)
 {
     register_interrupt_handler (handle_timer_interrupt, 0x30);
+
+    // Set up the pic chip
+    // Channel 0, access both bytes, square wave mode, binary mode
+    outb ((0 << 6) | (3 << 4)| (3 << 1) | (0 << 0), 0x43);
+    // Frequency divisor: 64
+    // Low byte: 64
+    outb (64, 0x40);
+    // High byte: 0
+    outb (0, 0x40);
     timer_driver.init = 0;
 }

--- a/kernel/arch/x86_64/kernel/drivers/pit/receiver.S
+++ b/kernel/arch/x86_64/kernel/drivers/pit/receiver.S
@@ -9,5 +9,18 @@ handle_timer_interrupt: /*Not used for now*/
 pushq %rax
 movb $0x20, %al
 outb %al, $0x20
+movq current_time_nanos, %rax
+addq $53638, %rax /*tick duration*/
+movq %rax, current_time_nanos
 popq %rax
 iretq
+
+.globl nanotime
+nanotime:
+movq current_time_nanos, %rax
+retq
+
+.data
+
+current_time_nanos:
+.quad 0

--- a/kernel/include/time.h
+++ b/kernel/include/time.h
@@ -1,0 +1,8 @@
+#ifndef _TIME_H
+#define _TIME_H  
+
+#include <stdint.h>
+
+u64_t nanotime();
+
+#endif

--- a/kernel/kernel/main.c
+++ b/kernel/kernel/main.c
@@ -2,16 +2,19 @@
 #include <drivers/init.h>
 #include <thread.h>
 #include <error.h>
+#include <time.h>
 
 void arch_init (void);
 
 void thread_start (void* arg)
 {
     char* char_arg = (char*)arg;
+    u64_t previous = 0;
     loop:
-    putchar (*char_arg);
-    notify (current_thread() == 1 ? 2 : 1);
-    wait ();
+    if (previous + 1000000000 <= nanotime ()) {
+        putchar (*char_arg);
+        previous = nanotime ();
+    }
     goto loop;
 }
 


### PR DESCRIPTION
This change adds the ability for the kernel to keep track of the time (in nanoseconds) and it is reported to anyone who asks for it. There is a nanotime function which simply returns the value of a counter in the pit driver.
Currently, this reports the real time, but it should be changed to report the cpu time of the current task so that it may be used for timing execution of programs/functions.