### PR TITLE
Read multiboot memory map

### DIFF
--- a/kernel/arch/x86_64/include/multiboot.h
+++ b/kernel/arch/x86_64/include/multiboot.h
@@ -57,7 +57,7 @@ typedef struct __attribute__((__packed__)) {
         u64_t length;
         u32_t type;
         u32_t reserved;
-    } memory_block [0];
+    } memory_blocks [0];
 } mbi_memory_map_tag_t;
 
 #endif

--- a/kernel/arch/x86_64/include/multiboot.h
+++ b/kernel/arch/x86_64/include/multiboot.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 
 #define MULTIBOOT_MBI_FRAME_BUFFER 8
+#define MULTIBOOT_MBI_MEMORY_MAP  6
 #define MBI_ALIGNMENT  8
 
 typedef struct __attribute__ ((__packed__)) {
@@ -45,5 +46,18 @@ typedef struct __attribute__ ((__packed__)) {
         } rgb;
     } color_descriptor;
 } mbi_frame_buffer_tag_t;
+
+typedef struct __attribute__((__packed__)) {
+    u32_t type;
+    u32_t size;
+    u32_t entry_size;
+    u32_t version;
+    struct __attribute__ ((__packed__)) {
+        u64_t address;
+        u64_t length;
+        u32_t type;
+        u32_t reserved;
+    } memory_block [0];
+} mbi_memory_map_tag_t;
 
 #endif

--- a/kernel/arch/x86_64/kernel/multiboot/mbi.c
+++ b/kernel/arch/x86_64/kernel/multiboot/mbi.c
@@ -1,5 +1,6 @@
 #include <multiboot.h>
 #include <frame_buffer.h>
+#include <memory/map.h>
 
 static frame_buffer_info_t frame_buffer = {
     .buffer = 0,
@@ -12,6 +13,10 @@ frame_buffer_info_t* get_frame_buffer ()
     return &frame_buffer;
 }
 
+static memory_map_t available_memory = {
+    .number_of_blocks = 0
+};
+
 extern u64_t multiboot_data_ptr;
 
 void process_tag (mbi_tag_t*  tag)
@@ -23,6 +28,20 @@ void process_tag (mbi_tag_t*  tag)
         frame_buffer.width = frame_buffer_ptr->width;
         frame_buffer.height = frame_buffer_ptr->height;
         frame_buffer.pitch = frame_buffer_ptr->pitch / 4;
+        }
+    }else if (tag->type == MULTIBOOT_MBI_MEMORY_MAP) {
+        mbi_memory_map_tag_t* memory_map_tag = (mbi_memory_map_tag_t*)tag;
+        if (memory_map_tag->entry_size == sizeof (memory_map_tag->memory_blocks [0])) {
+            u32_t number_of_entries = (memory_map_tag->size - sizeof (mbi_memory_map_tag_t)) / memory_map_tag->entry_size;
+            for (u32_t i = 0; i < number_of_entries; i ++) {
+                if (memory_map_tag->memory_blocks [i].type == 1) {
+                    memory_block_t memory_block;
+                    memory_block.base = (void*)memory_map_tag->memory_blocks [i].address;
+                    memory_block.length = memory_map_tag->memory_blocks [i].length;
+                    available_memory.blocks [available_memory.number_of_blocks] = memory_block;
+                    available_memory.number_of_blocks ++;
+                }
+            }
         }
     }
 }

--- a/kernel/arch/x86_64/kernel/multiboot/mbi.c
+++ b/kernel/arch/x86_64/kernel/multiboot/mbi.c
@@ -17,6 +17,10 @@ static memory_map_t available_memory = {
     .number_of_blocks = 0
 };
 
+memory_map_t* get_available_memory () {
+    return &available_memory;
+}
+
 extern u64_t multiboot_data_ptr;
 
 void process_tag (mbi_tag_t*  tag)

--- a/kernel/include/memory/map.h
+++ b/kernel/include/memory/map.h
@@ -1,0 +1,16 @@
+#ifndef _MEMORY_MAP_H
+#define _MEMORY_MAP_H  
+
+typedef struct {
+    void* base;
+    u64_t length;
+} memory_block_t;
+
+typedef struct {
+    u32_t number_of_blocks;
+    memory_block_t blocks [1024];
+} memory_map_t;
+
+memory_map_t* get_available_memory ();
+
+#endif

--- a/kernel/kernel/main.c
+++ b/kernel/kernel/main.c
@@ -3,6 +3,7 @@
 #include <thread.h>
 #include <error.h>
 #include <time.h>
+#include <memory/map.h>
 
 void arch_init (void);
 
@@ -34,6 +35,13 @@ void main (void)
     create_thread(&thread_id, thread_start, "A");
     puts ("Thread 2:");
     putnum64(thread_id, 10);
+    puts ("Available memory:");
+    u64_t available_memory = 0;
+    memory_map_t* available_memory_map = get_available_memory();
+    for (u32_t i = 0; i < available_memory_map->number_of_blocks; i ++) {
+        available_memory += available_memory_map->blocks [i].length;
+    }
+    puthex64 (available_memory);
     __asm__ ("sti");
     putchar ('\n');
     puts ("completed initialisation");    

--- a/kernel/kernel/stdio/conout.c
+++ b/kernel/kernel/stdio/conout.c
@@ -40,7 +40,7 @@ void putnum64 (u64_t num, int regex)
         buffer[count] = number_table [num % regex];
         count ++;
         num /= regex;
-    }while (num);
+    }while (num && count < 64);
     synchronise(&console_lock);
     for (; count-- > 0;) {
         console_write_char(buffer [count]);


### PR DESCRIPTION
Previously, the operating system had no idea about exactly how much ram was installed in the system. This feature makes the kernel print out how much memory the machine has, and keeps track of where the memory is in the physical address space. This will be useful when implementing a proper frame allocator.