### PR TITLE
Grub build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,17 @@ else
 	cp build/Micos $(DIR)/boot/Micos
 endif
 
-iso: $(KERNEL)
+efiimage:
+	@mkdir -p build/efi
+	@grub-mkimage -O x86_64-efi -p /boot/grub -o build/efi/BOOTX64.EFI part_msdos fat part_gpt all_video multiboot2
+
+iso: $(KERNEL) efiimage
 	@rm -rf build/boot
 	@mkdir -p build/grub/boot
 	@cp build/Micos build/grub/boot/Micos
 	@cp -r grub build/grub/boot/grub
+	mkdir -p build/grub/EFI/BOOT
+	@cp build/efi/BOOTX64.EFI build/grub/EFI/BOOT/BOOTX64.EFI
 	@grub-mkrescue -d /usr/lib/grub/i386-pc -o build/Micos.iso build/grub
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,12 @@ else
 	cp build/Micos $(DIR)/boot/Micos
 endif
 
+grub: $(KERNEL)
+	@rm -rf build/boot
+	@mkdir -p build/grub/boot
+	@cp build/Micos build/grub/boot/Micos
+	@cp -r grub build/boot/grub
+	@grub-mkrescue -d /usr/lib/grub/i386-pc -o build/Micos.iso build/grub
+
 clean:
 	@$(MAKE) -s -C kernel clean BASEDIR=kernel

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,11 @@ else
 	cp build/Micos $(DIR)/boot/Micos
 endif
 
-grub: $(KERNEL)
+iso: $(KERNEL)
 	@rm -rf build/boot
 	@mkdir -p build/grub/boot
 	@cp build/Micos build/grub/boot/Micos
-	@cp -r grub build/boot/grub
+	@cp -r grub build/grub/boot/grub
 	@grub-mkrescue -d /usr/lib/grub/i386-pc -o build/Micos.iso build/grub
 
 clean:

--- a/build/grub/boot/grub/grub.cfg
+++ b/build/grub/boot/grub/grub.cfg
@@ -1,0 +1,7 @@
+set timeout=0
+set default=0
+
+menuentry "Micos" {
+	multiboot2 /boot/Micos
+	boot
+}

--- a/build/grub/boot/grub/grub/grub.cfg
+++ b/build/grub/boot/grub/grub/grub.cfg
@@ -1,0 +1,7 @@
+set timeout=0
+set default=0
+
+menuentry "Micos" {
+	multiboot2 /boot/Micos
+	boot
+}

--- a/grub/grub.cfg
+++ b/grub/grub.cfg
@@ -1,0 +1,7 @@
+set timeout=0
+set default=0
+
+menuentry "Micos" {
+	multiboot2 /boot/Micos
+	boot
+}


### PR DESCRIPTION
Previously, to test the kernel, you would have to use an external build system to create a bootable iso image. This adds these build steps to the Makefile, allowing testers to build iso images without external build systems.