### PR TITLE
Create frame allocator functions for multiple frames

### DIFF
--- a/build/grub/boot/grub/grub/grub.cfg
+++ b/build/grub/boot/grub/grub/grub.cfg
@@ -1,7 +1,0 @@
-set timeout=0
-set default=0
-
-menuentry "Micos" {
-	multiboot2 /boot/Micos
-	boot
-}

--- a/build/grub/boot/grub/grub/grub.cfg
+++ b/build/grub/boot/grub/grub/grub.cfg
@@ -1,0 +1,7 @@
+set timeout=0
+set default=0
+
+menuentry "Micos" {
+	multiboot2 /boot/Micos
+	boot
+}

--- a/kernel/arch/x86_64/include/paging/frames.h
+++ b/kernel/arch/x86_64/include/paging/frames.h
@@ -6,8 +6,14 @@
 // Returns the index of the next free frame
 u64_t allocate_frame();
 
+// Same as above, except with multiple sequential frames
+u64_t allocate_frames(u64_t number_of_frames);
+
 // Adds the specified frame index to the pool of available frames
 void return_frame (u64_t index);
+
+// Same as above, except with multiple sequential frames
+void return_frames (u64_t start_index, u64_t number_of_frames);
 
 // Reserve the specified range of frames (inclusive)
 void reserve_frames (u64_t start_index, u64_t end_index);

--- a/kernel/arch/x86_64/kernel/paging/frames.c
+++ b/kernel/arch/x86_64/kernel/paging/frames.c
@@ -36,7 +36,6 @@ u64_t allocate_frame()
     {
         init();
     }
-    __asm__ volatile ("pleasestophere:");
     int i = 0;
     memory_block_t *tmp = &(free_memory.blocks[i]);
     // Select a block to get the frame from

--- a/kernel/arch/x86_64/kernel/paging/frames.c
+++ b/kernel/arch/x86_64/kernel/paging/frames.c
@@ -142,15 +142,8 @@ void reserve_frames(u64_t start_index, u64_t end_index)
         else if (start_index >= block_start && end_index <= block_end)
         {
             block->length = 0;
-            for (u64_t frame = block_start; frame <= block_end; frame++)
-            {
-                if (frame < start_index || frame > end_index)
-                {
-                    free_lock(&frame_lock);
-                    return_frame(frame);
-                    synchronise(&frame_lock);
-                }
-            }
+            return_frames(block_start, start_index - block_start);
+            return_frames(end_index, block_end - end_index);
         }
     }
     free_lock(&frame_lock);

--- a/kernel/arch/x86_64/kernel/paging/frames.c
+++ b/kernel/arch/x86_64/kernel/paging/frames.c
@@ -29,7 +29,7 @@ static void init()
     synchronise(&frame_lock);
 }
 
-u64_t allocate_frame()
+u64_t allocate_frames (u64_t number_of_frames)
 {
     synchronise(&frame_lock);
     if (free_memory.number_of_blocks == 0)
@@ -39,7 +39,7 @@ u64_t allocate_frame()
     int i = 0;
     memory_block_t *tmp = &(free_memory.blocks[i]);
     // Select a block to get the frame from
-    while (tmp->length == 0 && i < free_memory.number_of_blocks)
+    while (tmp->length < number_of_frames * 4096 && i < free_memory.number_of_blocks)
     {
         i++;
         tmp = &(free_memory.blocks[i]);
@@ -48,10 +48,14 @@ u64_t allocate_frame()
     {
         fatal_error("Could not locate a frame");
     }
-    tmp->length -= 4096;
+    tmp->length -= number_of_frames * 4096;
     u64_t frame = ((u64_t)tmp->base + tmp->length) / 4096;
     free_lock(&frame_lock);
     return frame;
+}
+
+u64_t allocate_frame () {
+    return allocate_frames (1);
 }
 
 void return_frame(u64_t index)

--- a/kernel/arch/x86_64/kernel/paging/frames.c
+++ b/kernel/arch/x86_64/kernel/paging/frames.c
@@ -46,12 +46,8 @@ u64_t allocate_frame()
     }
     if (i >= free_memory.number_of_blocks)
     {
-        __asm__ volatile ("anerroroccured:");
         fatal_error("Could not locate a frame");
     }
-    __asm__ volatile ("mov %0, %%rdi;"
-    "mov %1, %%rsi;"
-    "findoutwhattheblockis:" : : "g"(tmp->base), "g"(tmp->length) : "rdi", "rsi");
     tmp->length -= 4096;
     u64_t frame = ((u64_t)tmp->base + tmp->length) / 4096;
     free_lock(&frame_lock);


### PR DESCRIPTION
The frame allocator used to be quite simple. It would find the next frame in its pool and return it. This has some drawbacks, especially for return_frame. For example, if you want to reserve a large chunk of memory, the frame allocator would have to split the block into multiple blocks. Now, it is possible for the reserve_frames() function to be a lot faster.