### PR TITLE
moved the call to arch_init to the top of main()

### DIFF
--- a/kernel/kernel/main.c
+++ b/kernel/kernel/main.c
@@ -21,10 +21,10 @@ void thread_start (void* arg)
 
 void main (void)
 {
+    arch_init ();
     initialise_drivers (0);
     puts("Welcome to Micos");
     putchar ('\n');
-    arch_init ();
     initialise_drivers (1);
     initialise_drivers (2);
     initialise_drivers (3);


### PR DESCRIPTION
The kernel used to call initialise_drivers(0) before arch_init. This was because the arch_init function used to write to the console. Now, however, it does not, and can therefore be safely moved above the initialise_drivers(0) call. This will make exceptions from the call to initialise_drivers(0) be caught and hopefully handled correctly.