### PR TITLE
made map_physical_address() call reserve_frames() as well

### DIFF
--- a/kernel/arch/x86_64/kernel/paging/mapping.c
+++ b/kernel/arch/x86_64/kernel/paging/mapping.c
@@ -44,6 +44,7 @@ void *map_physical_address(void *address, size_t size)
     void *ptr = malloc(pages * 4096);
     u64_t frame_index = ((u64_t)address) / 4096;
     u64_t page_index = ((u64_t)ptr) / 4096;
+    reserve_frames(frame_index, frame_index + pages - 1);
     for (int i = 0; i < pages; i++)
     {
         map_page(frame_index + i, page_index + i, PAGE_PRESENT | PAGE_WRITABLE);


### PR DESCRIPTION
There didn't used to be a function to reserve the memory, so the map_physical_address function did not do this. However, after the introduction of the frame allocator, it is now possible. After the much better performance of reserve_frames() after #35, it is now safe to reserve the memory in this function. This will be useful when reserving things like multiboot modules, which are in main system memory and therefore in the frame allocator's pool.