### PR TITLE
Call arch init before main

### DIFF
--- a/kernel/arch/x86_64/init/finale.S
+++ b/kernel/arch/x86_64/init/finale.S
@@ -31,4 +31,7 @@ rep stosq
 /*find information such as the frame buffer location from the boot loader*/
 callq scan_mbi
 
+/*Early kernel setup*/
+callq arch_init
+
 jmp main /*into the main kernel code*/

--- a/kernel/kernel/main.c
+++ b/kernel/kernel/main.c
@@ -5,8 +5,6 @@
 #include <time.h>
 #include <memory/map.h>
 
-void arch_init (void);
-
 void thread_start (void* arg)
 {
     loop:
@@ -15,7 +13,6 @@ void thread_start (void* arg)
 
 void main (void)
 {
-    arch_init ();
     initialise_drivers (0);
     puts("Welcome to Micos");
     putchar ('\n');


### PR DESCRIPTION
For historical reasons, main() used to call arch_init(). Since this is no longer required, it can now be called before main() (in finale.S).