### PR TITLE
Specify alignment for malloc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "cstdlib": "c",
+        "page_tables.h": "c"
+    }
+}

--- a/kernel/arch/x86_64/kernel/paging/malloc/alloc.c
+++ b/kernel/arch/x86_64/kernel/paging/malloc/alloc.c
@@ -2,7 +2,7 @@
 #include "blocks.h"
 #include <paging/frames.h>
 
-void * malloc (size_t size)
+void * malloc (size_t size, unsigned int alignment)
 {
     size = (size + 4095 + 8) / 4096 * 4096; // page aligned
     void * ptr = reserve_block (size);

--- a/kernel/arch/x86_64/kernel/paging/malloc/alloc.c
+++ b/kernel/arch/x86_64/kernel/paging/malloc/alloc.c
@@ -20,10 +20,7 @@ void * malloc (size_t size, unsigned int alignment)
 
 void* malloc_uncacheable(size_t size, unsigned int alignment)
 {
-    if (!(alignment && (alignment - 1) & alignment)) {
-        fatal_error("Alignment for malloc must be a power of 2");
-    }
-    size = (size + 4095 + 8) / 4096 * 4096; // page aligned
+    size = (size + alignment - 1 + 8); // aligned
     void * ptr = reserve_block (size, alignment);
     u8_t * working_ptr = ptr;
     for (int i = 0; i < size; i+=4096){

--- a/kernel/arch/x86_64/kernel/paging/malloc/blocks.c
+++ b/kernel/arch/x86_64/kernel/paging/malloc/blocks.c
@@ -28,7 +28,7 @@ void create_block (memblock_t block)
     free_lock(&block_lock);
 }
 
-void * reserve_block (size_t size)
+void * reserve_block (size_t size, unsigned int alignment)
 {
     synchronise(&block_lock);
     if (!prepared) {
@@ -36,9 +36,9 @@ void * reserve_block (size_t size)
     }
     for (int i = start; i < end; i++) {
         memblock_t block = block_buffer [i];
-        if ((u64_t)(block.start - block.end) >= size) {
+        if ((u64_t)(((u64_t)block.start + alignment - 1) / alignment * alignment - (u64_t)block.end) >= size) {
             void * result = block.start;
-            block.start += size;
+            block.start += (size + alignment - 1) / alignment * alignment;
             block_buffer [i] = block;
             free_lock(&block_lock);
             return result;

--- a/kernel/arch/x86_64/kernel/paging/malloc/blocks.h
+++ b/kernel/arch/x86_64/kernel/paging/malloc/blocks.h
@@ -9,7 +9,8 @@ typedef struct {
 } memblock_t;
 
 void create_block (memblock_t block);
-void * reserve_block (size_t size);
+// Reserves the block from the block pool. The block will have enough space to fit the specified size, + any required alignment bytes.
+void * reserve_block (size_t size, unsigned int alignment);
 void clean_blocks ();
 
 #endif

--- a/kernel/arch/x86_64/kernel/paging/malloc/free.c
+++ b/kernel/arch/x86_64/kernel/paging/malloc/free.c
@@ -6,20 +6,14 @@ void free (void * ptr)
 {
     u8_t * working_ptr = ptr;
     working_ptr -= sizeof (size_t); // overhead
-    if ((u64_t)working_ptr % 4096) {
-        __asm__ ("int $0x1D"); // #pf if memory area is not page aligned
-    }
     size_t memblock_size = * ((size_t *)working_ptr);
-    if (memblock_size % 4096) {
-        __asm__ ("int $0x1D"); // #pf if size is not page aligned
-    }
     clean_blocks ();
     create_block ((memblock_t){
         .start = working_ptr, 
         .end = working_ptr + memblock_size
     });
     clean_blocks ();
-    for (u64_t address = (u64_t)working_ptr; address < (u64_t)working_ptr + memblock_size; address+=4096) {
+    for (u64_t address = (u64_t)(working_ptr + sizeof(size_t) + 4095) / 4096 * 4096; address < (u64_t)working_ptr + memblock_size; address+=4096) {
         unmap_page (address / 4096);
     }
 }

--- a/kernel/arch/x86_64/kernel/paging/mapping.c
+++ b/kernel/arch/x86_64/kernel/paging/mapping.c
@@ -41,7 +41,7 @@ void unmap_page(u64_t page_index)
 void *map_physical_address(void *address, size_t size)
 {
     u64_t pages = size / 4096 + 1;
-    void *ptr = malloc(pages * 4096);
+    void *ptr = malloc(pages * 4096, 4096);
     u64_t frame_index = ((u64_t)address) / 4096;
     u64_t page_index = ((u64_t)ptr) / 4096;
     reserve_frames(frame_index, frame_index + pages - 1);

--- a/kernel/arch/x86_64/kernel/thread/thread.c
+++ b/kernel/arch/x86_64/kernel/thread/thread.c
@@ -7,12 +7,12 @@
 
 int create_thread (thread_t* thread, void (*start)(void*), void* arg)
 {
-    int8_t* stack = malloc(THREAD_STACK_SIZE);
+    int8_t* stack = malloc(THREAD_STACK_SIZE, 1);
     if (stack == 0) {
         return 1;
     }
     stack += THREAD_STACK_SIZE;
-    task_state* task = malloc (sizeof (task_state));
+    task_state* task = malloc (sizeof (task_state), 1);
     if (task == 0) {
         return 1;
     }

--- a/kernel/include/common.h
+++ b/kernel/include/common.h
@@ -1,0 +1,7 @@
+#ifndef _COMMON_H
+#define _COMMON_H  
+
+#define MAX(X, Y)  ((X) > (Y) ? (X) : (Y))
+#define MIN(X, Y)  ((X) < (Y) ? (X) : (Y))
+
+#endif

--- a/kernel/include/malloc.h
+++ b/kernel/include/malloc.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-void * malloc (size_t size);
+void * malloc (size_t size, unsigned int alignment);
 void free (void * ptr);
 
 #endif

--- a/kernel/include/memory.h
+++ b/kernel/include/memory.h
@@ -6,6 +6,6 @@
 void* map_physical_address(void* physical_address, size_t size);
 void* map_physical_address_uncached(void* physical_address, size_t size);
 
-void* malloc_uncacheable(size_t size);
+void* malloc_uncacheable(size_t size, unsigned int alignment);
 
 #endif

--- a/kernel/kernel/drivers/pci/pci_table.c
+++ b/kernel/kernel/drivers/pci/pci_table.c
@@ -8,7 +8,7 @@ static pci_device_t * pci_table;
 
 void init_pci_table ()
 {
-    pci_table = malloc (pci_table_size * sizeof (pci_device_t));
+    pci_table = malloc (pci_table_size * sizeof (pci_device_t), 1);
 }
 
 void register_pci_device (pci_device_t device)
@@ -19,7 +19,7 @@ void register_pci_device (pci_device_t device)
 
 void register_pci_driver(int(*condition)(common_pci_header*), int(*init)(pci_device_t*)) 
 {
-    common_pci_header* pci_header = malloc(sizeof(common_pci_header));
+    common_pci_header* pci_header = malloc(sizeof(common_pci_header), 1);
     for (size_t i = 0; i < pci_entries; i ++) {
         pci_device_t* device = pci_table + i;
         *((u32_t*)pci_header + 0) = pci_read_configuration_register(device->bus, device->dev, 0, 0);


### PR DESCRIPTION
This adds a new parameter to malloc(): unsigned int alignment. This will align the result of the allocation to the specified alignment. Use an alignment of 1 for the previous behavior.
Another side effect of this is that malloc now allocates less memory per allocation, as it can just allocate what is required for the alignment constraints of the client.