### PR TITLE
made arch_init() call scan_mbi()

### DIFF
--- a/kernel/arch/x86_64/init/finale.S
+++ b/kernel/arch/x86_64/init/finale.S
@@ -28,9 +28,6 @@ subq $stack, %rcx
 shrq $3, %rcx
 rep stosq
 
-/*find information such as the frame buffer location from the boot loader*/
-callq scan_mbi
-
 /*Early kernel setup*/
 callq arch_init
 

--- a/kernel/arch/x86_64/kernel/init/main.c
+++ b/kernel/arch/x86_64/kernel/init/main.c
@@ -65,8 +65,11 @@ void init_interrupts ()
     return;
 }
 
+void scan_mbi();
+
 void arch_init ()
 {
+    scan_mbi();
     init_interrupts ();
     configure_pics ();
     return;


### PR DESCRIPTION
This makes the code a lot cleaner. Arch_init() can simply call scan_mbi() at the top, and the assembly code can just call arch_init(), and all is well.