### PR TITLE
Give threads names

### DIFF
--- a/kernel/arch/x86_64/kernel/thread/thread.c
+++ b/kernel/arch/x86_64/kernel/thread/thread.c
@@ -5,7 +5,7 @@
 
 #define THREAD_STACK_SIZE 65536
 
-int create_thread (thread_t* thread, void (*start)(void*), void* arg)
+int create_thread (thread_t* thread, void (*start)(void*), void* arg, const char* name)
 {
     int8_t* stack = malloc(THREAD_STACK_SIZE, 1);
     if (stack == 0) {
@@ -17,6 +17,7 @@ int create_thread (thread_t* thread, void (*start)(void*), void* arg)
         return 1;
     }
     memset(task, 0, sizeof (task_state));
+    task->name = name;
     task->registers.rip = start;
     task->registers.rflags = 0x200; // Enable external interrupts
     task->registers.rsp = stack;

--- a/kernel/include/task/state.h
+++ b/kernel/include/task/state.h
@@ -5,9 +5,10 @@
 
 typedef struct __attribute__((__packed__)) {
     register_state registers; // Registers, different for each architecture
+    const char* name;
     u32_t id; // Task id
     u8_t user; // User mode task?
-    u8_t wait, notify; // Wait and notify flags
+    u8_t wait, notify; // Wait and notify semaphores
 } task_state;
 
 #endif

--- a/kernel/include/thread.h
+++ b/kernel/include/thread.h
@@ -5,7 +5,7 @@
 
 typedef u32_t thread_t;
 
-int create_thread(thread_t* thread, void (*start)(void*), void* arg);
+int create_thread(thread_t* thread, void (*start)(void*), void* arg, const char* name);
 
 // Waits until a call to notify () with the current thread id
 void wait ();

--- a/kernel/kernel/main.c
+++ b/kernel/kernel/main.c
@@ -20,7 +20,7 @@ void main (void)
     initialise_drivers (2);
     initialise_drivers (3);
     thread_t thread_id;
-    create_thread(&thread_id, thread_start, "a");
+    create_thread(&thread_id, thread_start, "a", "Initial kernel thread");
     __asm__ ("sti");
     putchar ('\n');
     puts ("completed initialisation");    


### PR DESCRIPTION
This will allow future debuggers to give more information about the task states of the kernel to help with debugging.