### PR TITLE
Fixed printing off the screen bug

### DIFF
--- a/kernel/drivers/display/display.c
+++ b/kernel/drivers/display/display.c
@@ -32,7 +32,7 @@ void write_pixel(int x, int y, display_pixel pixel) {
     }
 }
 display_pixel get_pixel (int x, int y) {
-    return * (frame_buffer.buffer + (y * frame_buffer.width + x));
+    return * (frame_buffer.buffer + (y * frame_buffer.pitch + x));
 }
 
 video_mode* get_video_mode () {

--- a/kernel/kernel/drivers/console/console.c
+++ b/kernel/kernel/drivers/console/console.c
@@ -35,7 +35,7 @@ void console_write_char(u32_t character) {
     if (lines == 0 || characters_per_line == 0) {
         vidmode = *get_video_mode();
         lines = vidmode.height / get_character_height ();
-        characters_per_line = vidmode.width / get_character_width ();
+        characters_per_line = vidmode.width / (get_character_width () + 1);
         current_x = 0;
         current_y = 0;
     }


### PR DESCRIPTION
The console system used to sometimes print characters off the right of the screen. This was because it had the wrong information about the character width. This fixes the bug.