### PR TITLE
added the 32bit variations of strlen and strcpy

### DIFF
--- a/kernel/include/strings.h
+++ b/kernel/include/strings.h
@@ -9,4 +9,7 @@ void * memcpy (void * src, void * dst, size_t size);
 int strlen(const char* str);
 int strcpy(char* dest, const char* src);
 
+int strlen32(const u32_t* str);
+int strcpy32(u32_t* dest, const u32_t* src);
+
 #endif

--- a/kernel/kernel/strings/strops.c
+++ b/kernel/kernel/strings/strops.c
@@ -12,3 +12,15 @@ int strcpy(char* dest, const char* src) {
     }while (src[i++]);
     return i - 1;
 }
+int strlen32(const u32_t* str) {
+    int i = 0;
+    while (str[i++]);
+    return i - 1;
+}
+int strcpy32(u32_t* dest, const u32_t* src) {
+    int i = 0;
+    do {
+        dest[i] = src[i];
+    }while (src[i++]);
+    return i - 1;
+}


### PR DESCRIPTION
This will be useful for the console driver, which uses u32_ts instead of chars for unicode purposes.