### PR TITLE
Implement fast console scrolling

### DIFF
--- a/kernel/include/strings.h
+++ b/kernel/include/strings.h
@@ -8,8 +8,10 @@ void * memcpy (void * src, void * dst, size_t size);
 
 int strlen(const char* str);
 int strcpy(char* dest, const char* src);
+int strappend(char* str, char c);
 
 int strlen32(const u32_t* str);
 int strcpy32(u32_t* dest, const u32_t* src);
+int strappend32(u32_t* str, u32_t n);
 
 #endif

--- a/kernel/kernel/drivers/console/console.c
+++ b/kernel/kernel/drivers/console/console.c
@@ -57,6 +57,7 @@ static inline void new_line()
     current_x = 0;
     current_y++;
     check_and_scroll();
+    set_character_at(0, current_y, 0);
 }
 
 void console_write_char(u32_t character)
@@ -69,6 +70,7 @@ void console_write_char(u32_t character)
         current_x = 0;
         current_y = 0;
         screen_buffer = calloc(lines * (characters_per_line + 1), sizeof(u32_t), 1);
+        *screen_buffer = 0;
     }
     if (character == '\n')
     {

--- a/kernel/kernel/drivers/console/console.c
+++ b/kernel/kernel/drivers/console/console.c
@@ -83,7 +83,7 @@ void console_write_char(u32_t character)
         {
             current_x--;
             render_character(current_x, current_y, ' ', default_foreground, default_background);
-            screen_buffer[current_y * characters_per_line + current_x] = 0;
+            set_character_at(current_x, current_y, 0);
         }
     }
     else

--- a/kernel/kernel/drivers/console/console.c
+++ b/kernel/kernel/drivers/console/console.c
@@ -1,6 +1,7 @@
 #include <fonts/renderer.h>
 #include <display.h>
 #include <strings.h>
+#include <malloc.h>
 
 static int current_x = 0;
 static int current_y = 0;
@@ -9,6 +10,8 @@ static int characters_per_line;
 static int lines;
 
 static video_mode vidmode;
+
+static u32_t* screen_buffer;
 
 static void check_position_is_in_bounds () {
     if (current_x >= characters_per_line) {
@@ -38,6 +41,7 @@ void console_write_char(u32_t character) {
         characters_per_line = vidmode.width / (get_character_width () + 1);
         current_x = 0;
         current_y = 0;
+        screen_buffer = calloc(lines * characters_per_line, sizeof(u32_t), 1);
     }
     if (character == '\n') {
         current_y ++;

--- a/kernel/kernel/drivers/console/console.c
+++ b/kernel/kernel/drivers/console/console.c
@@ -3,9 +3,9 @@
 #include <strings.h>
 #include <malloc.h>
 
-#define get_start_of_line(line) (screen_buffer + line * (characters_per_line + 1))
-#define get_character_at(x, y) (*(get_start_of_line(y) + x))
-#define set_character_at(x, y, character) (*(get_start_of_line(y) + x) = character)
+#define get_start_of_line(line) (screen_buffer + (line) * (characters_per_line + 1))
+#define get_character_at(x, y) (*(get_start_of_line(y) + (x)))
+#define set_character_at(x, y, character) (*(get_start_of_line(y) + (x)) = (character))
 
 #define get_line_length(line) strlen32(get_start_of_line(line))
 

--- a/kernel/kernel/drivers/console/console.c
+++ b/kernel/kernel/drivers/console/console.c
@@ -89,7 +89,8 @@ void console_write_char(u32_t character)
     else
     {
         render_character(current_x, current_y, character, default_foreground, default_background);
-        strappend32(screen_buffer + current_y * (characters_per_line + 1), character);
+        set_character_at(current_x, current_y, character);
+        set_character_at(current_x + 1, current_y, 0);
         current_x++;
         if (current_x >= characters_per_line)
         {

--- a/kernel/kernel/drivers/console/console.c
+++ b/kernel/kernel/drivers/console/console.c
@@ -3,6 +3,12 @@
 #include <strings.h>
 #include <malloc.h>
 
+#define get_start_of_line(line) (screen_buffer + line * (characters_per_line + 1))
+#define get_character_at(x, y) (*(get_start_of_line(y) + x))
+#define set_character_at(x, y, character) (*(get_start_of_line(y) + x) = character)
+
+#define get_line_length(line) strlen32(get_start_of_line(line))
+
 static int current_x = 0;
 static int current_y = 0;
 
@@ -11,65 +17,83 @@ static int lines;
 
 static video_mode vidmode;
 
-static u32_t* screen_buffer;
+static u32_t *screen_buffer;
 
 static display_pixel default_foreground = {
     .red = 0xFF,
     .green = 0xFF,
     .blue = 0xFF,
-    .alpha = 0xFF
-};
+    .alpha = 0xFF};
 static display_pixel default_background = {};
 
-static void check_position_is_in_bounds () {
-    if (current_x >= characters_per_line) {
-        current_x = 0;
-        current_y ++;
-    }
-    if (current_y >= lines) {
-        for (int line = 1; line < lines; line ++) {
-            int previous_line_length = strlen32(screen_buffer + (line - 1) * (characters_per_line + 1));
-            int current_line_length = strlen32(screen_buffer + line * (characters_per_line + 1));
-                for (int x = current_line_length; x < previous_line_length; x ++) {
-                    render_character(x, line - 1, ' ', default_foreground, default_background);
+static void check_and_scroll()
+{
+    if (current_y >= lines)
+    {
+        for (int line = 1; line < lines; line++)
+        {
+            int previous_line_length = get_line_length(line - 1);
+            int current_line_length = get_line_length(line);
+            for (int x = current_line_length; x < previous_line_length; x++)
+            {
+                render_character(x, line - 1, ' ', default_foreground, default_background);
             }
-            strcpy32(screen_buffer + (line - 1) * (characters_per_line + 1), screen_buffer + line * (characters_per_line + 1));
-            for (int x = 0; x < current_line_length; x ++) {
-                render_character(x, line - 1, screen_buffer[line * (characters_per_line + 1) + x], default_foreground, default_background);
+            strcpy32(get_start_of_line(line - 1), get_start_of_line(line));
+            for (int x = 0; x < current_line_length; x++)
+            {
+                render_character(x, line - 1, get_character_at(x, line - 1), default_foreground, default_background);
             }
         }
-        int final_line_length = strlen32(screen_buffer + (lines - 1) * (characters_per_line + 1));
-        for (int x = 0; x <= final_line_length; x ++) {
+        int final_line_length = get_line_length(lines - 1);
+        for (int x = 0; x < final_line_length; x++)
+        {
             render_character(x, lines - 1, ' ', default_foreground, default_background);
         }
-        screen_buffer[(lines - 1) * (characters_per_line + 1)] = 0;
+        set_character_at(0, lines - 1, 0);
         current_y = lines - 1;
         current_x = 0;
     }
 }
 
-void console_write_char(u32_t character) {
-    if (lines == 0 || characters_per_line == 0) {
+static inline void new_line()
+{
+    current_x = 0;
+    current_y++;
+    check_and_scroll();
+}
+
+void console_write_char(u32_t character)
+{
+    if (lines == 0 || characters_per_line == 0)
+    {
         vidmode = *get_video_mode();
-        lines = vidmode.height / get_character_height ();
-        characters_per_line = vidmode.width / (get_character_width () + 1);
+        lines = vidmode.height / get_character_height();
+        characters_per_line = vidmode.width / (get_character_width() + 1);
         current_x = 0;
         current_y = 0;
         screen_buffer = calloc(lines * (characters_per_line + 1), sizeof(u32_t), 1);
     }
-    if (character == '\n') {
-        current_y ++;
-        current_x = 0;
-    }else if (character == 0x8) {
-        if (current_x > 0) {
-            current_x --;
+    if (character == '\n')
+    {
+        new_line();
+    }
+    else if (character == 0x8)
+    {
+        if (current_x > 0)
+        {
+            current_x--;
             render_character(current_x, current_y, ' ', default_foreground, default_background);
             screen_buffer[current_y * characters_per_line + current_x] = 0;
         }
-}else {
-        render_character(current_x, current_y, character, default_foreground, default_background);
-        strappend32(screen_buffer + current_y * characters_per_line, character);
-        current_x ++;
     }
-    check_position_is_in_bounds();
+    else
+    {
+        render_character(current_x, current_y, character, default_foreground, default_background);
+        strappend32(screen_buffer + current_y * (characters_per_line + 1), character);
+        current_x++;
+        if (current_x >= characters_per_line)
+        {
+            new_line();
+        }
+    }
 }

--- a/kernel/kernel/drivers/console/console.c
+++ b/kernel/kernel/drivers/console/console.c
@@ -41,7 +41,7 @@ void console_write_char(u32_t character) {
         characters_per_line = vidmode.width / (get_character_width () + 1);
         current_x = 0;
         current_y = 0;
-        screen_buffer = calloc(lines * characters_per_line, sizeof(u32_t), 1);
+        screen_buffer = calloc(lines * (characters_per_line + 1), sizeof(u32_t), 1);
     }
     if (character == '\n') {
         current_y ++;
@@ -50,9 +50,11 @@ void console_write_char(u32_t character) {
         if (current_x > 0) {
             current_x --;
             render_character(current_x, current_y, ' ', default_foreground, default_background);
+            screen_buffer[current_y * characters_per_line + current_x] = 0;
         }
 }else {
         render_character(current_x, current_y, character, default_foreground, default_background);
+        strappend32(screen_buffer + current_y * characters_per_line, character);
         current_x ++;
     }
     check_position_is_in_bounds();

--- a/kernel/kernel/drivers/console/console.c
+++ b/kernel/kernel/drivers/console/console.c
@@ -41,7 +41,7 @@ static void check_and_scroll()
             strcpy32(get_start_of_line(line - 1), get_start_of_line(line));
             for (int x = 0; x < current_line_length; x++)
             {
-                render_character(x, line - 1, get_character_at(x, line - 1), default_foreground, default_background);
+                render_character(x, line - 1, get_character_at(x, line), default_foreground, default_background);
             }
         }
         int final_line_length = get_line_length(lines - 1);
@@ -72,6 +72,8 @@ void console_write_char(u32_t character)
         current_x = 0;
         current_y = 0;
         screen_buffer = calloc(lines * (characters_per_line + 1), sizeof(u32_t), 1);
+        __asm__("mov %0, %%edi;"
+            "stophere:" : : "g"(*screen_buffer) : "rdi");
     }
     if (character == '\n')
     {

--- a/kernel/kernel/drivers/console/console.c
+++ b/kernel/kernel/drivers/console/console.c
@@ -35,7 +35,7 @@ static void check_position_is_in_bounds () {
             }
             strcpy32(screen_buffer + (line - 1) * (characters_per_line + 1), screen_buffer + line * (characters_per_line + 1));
             for (int x = 0; x < current_line_length; x ++) {
-                render_character(x, line - 1, screen_buffer[(line - 1) * (characters_per_line + 1) + x], default_foreground, default_background);
+                render_character(x, line - 1, screen_buffer[line * (characters_per_line + 1) + x], default_foreground, default_background);
             }
         }
         int final_line_length = strlen32(screen_buffer + (lines - 1) * (characters_per_line + 1));

--- a/kernel/kernel/drivers/console/console.c
+++ b/kernel/kernel/drivers/console/console.c
@@ -34,18 +34,15 @@ static void check_and_scroll()
         {
             int previous_line_length = get_line_length(line - 1);
             int current_line_length = get_line_length(line);
-            for (int x = current_line_length; x < previous_line_length; x++)
-            {
-                render_character(x, line - 1, ' ', default_foreground, default_background);
-            }
             strcpy32(get_start_of_line(line - 1), get_start_of_line(line));
-            for (int x = 0; x < current_line_length; x++)
+            for (int x = 0; x < current_line_length || x < previous_line_length; x++)
             {
-                render_character(x, line - 1, get_character_at(x, line), default_foreground, default_background);
+                u32_t current_character = get_character_at(x, line);
+                render_character(x, line - 1, x < current_line_length ? current_character : ' ', default_foreground, default_background);
             }
         }
         int final_line_length = get_line_length(lines - 1);
-        for (int x = 0; x < final_line_length; x++)
+        for (int x = 0; x <= final_line_length; x++)
         {
             render_character(x, lines - 1, ' ', default_foreground, default_background);
         }
@@ -72,8 +69,6 @@ void console_write_char(u32_t character)
         current_x = 0;
         current_y = 0;
         screen_buffer = calloc(lines * (characters_per_line + 1), sizeof(u32_t), 1);
-        __asm__("mov %0, %%edi;"
-            "stophere:" : : "g"(*screen_buffer) : "rdi");
     }
     if (character == '\n')
     {

--- a/kernel/kernel/memory/memops.c
+++ b/kernel/kernel/memory/memops.c
@@ -3,6 +3,8 @@
 
 void* calloc(size_t number, size_t size, unsigned int alignment) {
     void* memory = malloc(number * size, alignment);
-    memset(memory, 0, number * size);
+    for (int i = 0; i < number * size; i ++) {
+        *((u8_t*)memory) = 0;
+    }
     return memory;
 }

--- a/kernel/kernel/strings/strops.c
+++ b/kernel/kernel/strings/strops.c
@@ -12,6 +12,13 @@ int strcpy(char* dest, const char* src) {
     }while (src[i++]);
     return i - 1;
 }
+int strappend(char* str, char c) {
+    int len = strlen(str);
+    str[len] = c;
+    len++;
+    str[len] = 0;
+    return len;
+}
 int strlen32(const u32_t* str) {
     int i = 0;
     while (str[i++]);
@@ -23,4 +30,11 @@ int strcpy32(u32_t* dest, const u32_t* src) {
         dest[i] = src[i];
     }while (src[i++]);
     return i - 1;
+}
+int strappend32(u32_t* str, u32_t n) {
+    int len = strlen32(str);
+    str[len] = n;
+    len++;
+    str[len] = 0;
+    return len;
 }


### PR DESCRIPTION
The way the console used to scroll was by copying each and every one of the pixels on the screen one row upwards. This worked fine, except that on some machines it was extremely slow. This fixes this problem. The console is scrolled by copying each of the characters up a line, which makes it a lot faster, especially if there is not much on the screen to begin with.