### PR TITLE
Identify boot modules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "files.associations": {
+        "cstring": "c",
+        "xmemory": "c",
+        "xutility": "c"
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,11 @@ ifeq (,$(DIR))
 	@echo $(DIR)
 	@echo "please provide a valid path with DIR=/path/to/install/dir"
 else
-	@mkdir -p $(DIR)/boot
+	@mkdir -p $(DIR)/boot/grub
 	@rm -f $(DIR)/boot/Micos
 	cp build/Micos $(DIR)/boot/Micos
+	@rm -f $(DIR)/boot/grub/grub.cfg
+	cp grub/grub.cfg $(DIR)/boot/grub/grub.cfg
 endif
 
 efiimage:

--- a/grub/grub.cfg
+++ b/grub/grub.cfg
@@ -3,5 +3,6 @@ set default=0
 
 menuentry "Micos" {
 	multiboot2 /boot/Micos
+	module2 /boot/grub/grub.cfg
 	boot
 }

--- a/grub/grub.cfg
+++ b/grub/grub.cfg
@@ -3,6 +3,6 @@ set default=0
 
 menuentry "Micos" {
 	multiboot2 /boot/Micos
-	module2 /boot/grub/grub.cfg
+	module2 /boot/grub/grub.cfg test
 	boot
 }

--- a/kernel/arch/x86_64/head/head.S
+++ b/kernel/arch/x86_64/head/head.S
@@ -15,6 +15,9 @@ information_request_start:
 .word 1 /*type*/
 .word 0 /*flags*/
 .long information_request_end - information_request_start /*size*/
+.long 3 /*modules*/
+.long 8 /*frame buffer*/
+.long 6 /*memory map*/
 information_request_end:
 
 /*Frame buffer*/
@@ -25,6 +28,12 @@ information_request_end:
 .long 0 /*width, kernel doesn't mind*/
 .long 0 /*height, kernel doesn't mind*/
 .long 32 /*bits per pixel*/
+
+/*Module alignment tag*/
+.align 8
+.word 6
+.word 0
+.long 8
 
 /*end tag*/
 .align 8

--- a/kernel/arch/x86_64/include/multiboot.h
+++ b/kernel/arch/x86_64/include/multiboot.h
@@ -5,6 +5,7 @@
 
 #define MULTIBOOT_MBI_FRAME_BUFFER 8
 #define MULTIBOOT_MBI_MEMORY_MAP  6
+#define MULTIBOOT_MBI_BOOT_MODULE  3
 #define MBI_ALIGNMENT  8
 
 typedef struct __attribute__ ((__packed__)) {
@@ -59,5 +60,13 @@ typedef struct __attribute__((__packed__)) {
         u32_t reserved;
     } memory_blocks [0];
 } mbi_memory_map_tag_t;
+
+typedef struct __attribute__((__packed__)) {
+    u32_t type;
+    u32_t size;
+    u32_t start;
+    u32_t end;
+    u8_t name[0];
+} mbi_boot_module_tag_t;
 
 #endif

--- a/kernel/arch/x86_64/include/multiboot.h
+++ b/kernel/arch/x86_64/include/multiboot.h
@@ -66,7 +66,7 @@ typedef struct __attribute__((__packed__)) {
     u32_t size;
     u32_t start;
     u32_t end;
-    u8_t name[0];
+    char name[0];
 } mbi_boot_module_tag_t;
 
 #endif

--- a/kernel/arch/x86_64/kernel/memory/memops.S
+++ b/kernel/arch/x86_64/kernel/memory/memops.S
@@ -9,6 +9,7 @@ memset:
 /*rdi contains the pointer, rsi contains the value to set and rdx contains the size of the block to set*/
 /*this corresponds to the c function declaration void memset (void * ptr, char c, size_t size);*/
 pushq %rdi
+xorl %eax, %eax
 movb %sil, %al
 movq $0x0101010101010101, %rcx
 movq %rdx, %r11

--- a/kernel/arch/x86_64/kernel/multiboot/mbi.c
+++ b/kernel/arch/x86_64/kernel/multiboot/mbi.c
@@ -93,6 +93,8 @@ void scan_mbi()
     for (int i = 0; i < number_of_modules; i++)
     {
         mbi_boot_module_tag_t *module_tag = (mbi_boot_module_tag_t *)(mbi_ptr + module_offsets[i]);
+        __asm__ volatile ("mov %0, %%rdi;"
+        "stophere:" : : "g"(module_tag->size) : "rdi");
         u32_t size = module_tag->end - module_tag->start;
         void *module_data = map_physical_address((void *)module_tag->start, size);
         int name_size = strlen(module_tag->name);

--- a/kernel/arch/x86_64/kernel/multiboot/mbi.c
+++ b/kernel/arch/x86_64/kernel/multiboot/mbi.c
@@ -67,5 +67,5 @@ void scan_mbi()
         process_tag((mbi_tag_t *)mbi_ptr);
         mbi_ptr += ((tag.size + MBI_ALIGNMENT - 1) / 8) * 8;
     }
-    mbi_ptr = (u64_t)map_physical_address((void*)mbi_ptr, *((u32_t*)mbi_ptr));
+    mbi_ptr = (u64_t)map_physical_address((void*)multiboot_data_ptr, *((u32_t*)multiboot_data_ptr));
 }

--- a/kernel/arch/x86_64/kernel/multiboot/mbi.c
+++ b/kernel/arch/x86_64/kernel/multiboot/mbi.c
@@ -2,6 +2,7 @@
 #include <frame_buffer.h>
 #include <memory/map.h>
 #include <memory.h>
+#include <modules.h>
 
 static frame_buffer_info_t frame_buffer = {
     .buffer = 0,
@@ -20,6 +21,14 @@ memory_map_t *get_available_memory()
 {
     return &available_memory;
 }
+
+#define MAX_MODULES  4
+
+static int number_of_modules = 0;
+
+static u64_t module_offsets[MAX_MODULES];
+
+static boot_module_t boot_modules[MAX_MODULES];
 
 extern u64_t multiboot_data_ptr;
 
@@ -54,6 +63,12 @@ void process_tag(mbi_tag_t *tag)
                 }
             }
         }
+    }
+    else if (tag->type == MULTIBOOT_MBI_BOOT_MODULE) {
+        if (number_of_modules >= MAX_MODULES) {
+            return;
+        }
+        module_offsets[number_of_modules++] = (u64_t)tag - multiboot_data_ptr;
     }
 }
 

--- a/kernel/arch/x86_64/kernel/multiboot/mbi.c
+++ b/kernel/arch/x86_64/kernel/multiboot/mbi.c
@@ -93,12 +93,10 @@ void scan_mbi()
     for (int i = 0; i < number_of_modules; i++)
     {
         mbi_boot_module_tag_t *module_tag = (mbi_boot_module_tag_t *)(mbi_ptr + module_offsets[i]);
-        __asm__ volatile ("mov %0, %%rdi;"
-        "stophere:" : : "g"(module_tag->size) : "rdi");
         u32_t size = module_tag->end - module_tag->start;
         void *module_data = map_physical_address((void *)module_tag->start, size);
         int name_size = strlen(module_tag->name);
-        boot_module_t *module = malloc(sizeof(boot_module_t) + name_size + 1, 1);
+        boot_module_t *module = malloc(sizeof(boot_module_t) + name_size + 1, 4096);
         strcpy(module->name, module_tag->name);
         module->size = size;
         module->start = module_data;

--- a/kernel/arch/x86_64/kernel/multiboot/mbi.c
+++ b/kernel/arch/x86_64/kernel/multiboot/mbi.c
@@ -24,13 +24,15 @@ memory_map_t *get_available_memory()
     return &available_memory;
 }
 
-#define MAX_MODULES  4
-
 static int number_of_modules = 0;
 
 static u64_t module_offsets[MAX_MODULES];
 
-static boot_module_t* boot_modules[MAX_MODULES];
+static boot_module_t* boot_modules[MAX_MODULES] = {0};
+
+boot_module_t* get_boot_module(int number) {
+    return boot_modules[number];
+}
 
 extern u64_t multiboot_data_ptr;
 

--- a/kernel/arch/x86_64/kernel/multiboot/mbi.c
+++ b/kernel/arch/x86_64/kernel/multiboot/mbi.c
@@ -1,61 +1,71 @@
 #include <multiboot.h>
 #include <frame_buffer.h>
 #include <memory/map.h>
+#include <memory.h>
 
 static frame_buffer_info_t frame_buffer = {
     .buffer = 0,
     .width = 0,
-    .height = 0
-};
+    .height = 0};
 
-frame_buffer_info_t* get_frame_buffer ()
+frame_buffer_info_t *get_frame_buffer()
 {
     return &frame_buffer;
 }
 
 static memory_map_t available_memory = {
-    .number_of_blocks = 0
-};
+    .number_of_blocks = 0};
 
-memory_map_t* get_available_memory () {
+memory_map_t *get_available_memory()
+{
     return &available_memory;
 }
 
 extern u64_t multiboot_data_ptr;
 
-void process_tag (mbi_tag_t*  tag)
+void process_tag(mbi_tag_t *tag)
 {
-    if (tag->type == MULTIBOOT_MBI_FRAME_BUFFER) {
-        mbi_frame_buffer_tag_t * frame_buffer_ptr = (mbi_frame_buffer_tag_t *)tag;
-        if (frame_buffer_ptr->pixel_bits == 32) {
-        frame_buffer.buffer = (frame_buffer_cell *)frame_buffer_ptr->address;
-        frame_buffer.width = frame_buffer_ptr->width;
-        frame_buffer.height = frame_buffer_ptr->height;
-        frame_buffer.pitch = frame_buffer_ptr->pitch / 4;
+    if (tag->type == MULTIBOOT_MBI_FRAME_BUFFER)
+    {
+        mbi_frame_buffer_tag_t *frame_buffer_ptr = (mbi_frame_buffer_tag_t *)tag;
+        if (frame_buffer_ptr->pixel_bits == 32)
+        {
+            frame_buffer.buffer = (frame_buffer_cell *)frame_buffer_ptr->address;
+            frame_buffer.width = frame_buffer_ptr->width;
+            frame_buffer.height = frame_buffer_ptr->height;
+            frame_buffer.pitch = frame_buffer_ptr->pitch / 4;
         }
-    }else if (tag->type == MULTIBOOT_MBI_MEMORY_MAP) {
-        mbi_memory_map_tag_t* memory_map_tag = (mbi_memory_map_tag_t*)tag;
-        if (memory_map_tag->entry_size == sizeof (memory_map_tag->memory_blocks [0])) {
-            u32_t number_of_entries = (memory_map_tag->size - sizeof (mbi_memory_map_tag_t)) / memory_map_tag->entry_size;
-            for (u32_t i = 0; i < number_of_entries; i ++) {
-                if (memory_map_tag->memory_blocks [i].type == 1) {
+    }
+    else if (tag->type == MULTIBOOT_MBI_MEMORY_MAP)
+    {
+        mbi_memory_map_tag_t *memory_map_tag = (mbi_memory_map_tag_t *)tag;
+        if (memory_map_tag->entry_size == sizeof(memory_map_tag->memory_blocks[0]))
+        {
+            u32_t number_of_entries = (memory_map_tag->size - sizeof(mbi_memory_map_tag_t)) / memory_map_tag->entry_size;
+            for (u32_t i = 0; i < number_of_entries; i++)
+            {
+                if (memory_map_tag->memory_blocks[i].type == 1)
+                {
                     memory_block_t memory_block;
-                    memory_block.base = (void*)memory_map_tag->memory_blocks [i].address;
-                    memory_block.length = memory_map_tag->memory_blocks [i].length;
-                    available_memory.blocks [available_memory.number_of_blocks] = memory_block;
-                    available_memory.number_of_blocks ++;
+                    memory_block.base = (void *)memory_map_tag->memory_blocks[i].address;
+                    memory_block.length = memory_map_tag->memory_blocks[i].length;
+                    available_memory.blocks[available_memory.number_of_blocks] = memory_block;
+                    available_memory.number_of_blocks++;
                 }
             }
         }
     }
 }
 
-void scan_mbi ()
+void scan_mbi()
 {
-    u64_t mbi_ptr = multiboot_data_ptr + 8; /*first tag*/
-    while (((mbi_tag_t *)mbi_ptr)-> type) {
-        mbi_tag_t tag = * ((mbi_tag_t *)mbi_ptr);
-        process_tag ((mbi_tag_t *)mbi_ptr);
+    u64_t mbi_ptr = multiboot_data_ptr;
+    mbi_ptr+=8;
+    while (((mbi_tag_t *)mbi_ptr)->type)
+    {
+        mbi_tag_t tag = *((mbi_tag_t *)mbi_ptr);
+        process_tag((mbi_tag_t *)mbi_ptr);
         mbi_ptr += ((tag.size + MBI_ALIGNMENT - 1) / 8) * 8;
     }
+    mbi_ptr = (u64_t)map_physical_address((void*)mbi_ptr, *((u32_t*)mbi_ptr));
 }

--- a/kernel/arch/x86_64/kernel/multiboot/mbi.c
+++ b/kernel/arch/x86_64/kernel/multiboot/mbi.c
@@ -28,9 +28,10 @@ static int number_of_modules = 0;
 
 static u64_t module_offsets[MAX_MODULES];
 
-static boot_module_t* boot_modules[MAX_MODULES] = {0};
+static boot_module_t *boot_modules[MAX_MODULES] = {0};
 
-boot_module_t* get_boot_module(int number) {
+boot_module_t *get_boot_module(int number)
+{
     return boot_modules[number];
 }
 
@@ -68,8 +69,10 @@ void process_tag(mbi_tag_t *tag)
             }
         }
     }
-    else if (tag->type == MULTIBOOT_MBI_BOOT_MODULE) {
-        if (number_of_modules >= MAX_MODULES) {
+    else if (tag->type == MULTIBOOT_MBI_BOOT_MODULE)
+    {
+        if (number_of_modules >= MAX_MODULES)
+        {
             return;
         }
         module_offsets[number_of_modules++] = (u64_t)tag - multiboot_data_ptr;
@@ -79,24 +82,25 @@ void process_tag(mbi_tag_t *tag)
 void scan_mbi()
 {
     u64_t mbi_ptr = multiboot_data_ptr;
-    mbi_ptr+=8;
+    mbi_ptr += 8;
     while (((mbi_tag_t *)mbi_ptr)->type)
     {
         mbi_tag_t tag = *((mbi_tag_t *)mbi_ptr);
         process_tag((mbi_tag_t *)mbi_ptr);
         mbi_ptr += ((tag.size + MBI_ALIGNMENT - 1) / 8) * 8;
     }
-    mbi_ptr = (u64_t)map_physical_address((void*)multiboot_data_ptr, *((u32_t*)multiboot_data_ptr));
-    for (int i = 0; i < number_of_modules; i ++) {
-        mbi_boot_module_tag_t* module_tag = (mbi_boot_module_tag_t*)(mbi_ptr + module_offsets[i]);
+    mbi_ptr = (u64_t)map_physical_address((void *)multiboot_data_ptr, *((u32_t *)multiboot_data_ptr));
+    for (int i = 0; i < number_of_modules; i++)
+    {
+        mbi_boot_module_tag_t *module_tag = (mbi_boot_module_tag_t *)(mbi_ptr + module_offsets[i]);
         u32_t size = module_tag->end - module_tag->start;
-        void* module_data = map_physical_address((void*)module_tag->start, size);
+        void *module_data = map_physical_address((void *)module_tag->start, size);
         int name_size = strlen(module_tag->name);
-        boot_module_t* module = malloc(sizeof(boot_module_t) + name_size + 1, 1);
+        boot_module_t *module = malloc(sizeof(boot_module_t) + name_size + 1, 1);
         strcpy(module->name, module_tag->name);
         module->size = size;
         module->start = module_data;
         boot_modules[i] = module;
     }
-    free((void*)mbi_ptr);
+    free((void *)mbi_ptr);
 }

--- a/kernel/include/modules.h
+++ b/kernel/include/modules.h
@@ -3,10 +3,14 @@
 
 #include <stdint.h>
 
+#define MAX_MODULES  4
+
 typedef struct {
     void* start;
     u64_t size;
     char name[0];
 } boot_module_t;
+
+boot_module_t* get_boot_module(int number);
 
 #endif

--- a/kernel/include/modules.h
+++ b/kernel/include/modules.h
@@ -1,0 +1,12 @@
+#ifndef _MODULES_H
+#define _MODULES_H  
+
+#include <stdint.h>
+
+typedef struct {
+    void* start;
+    u64_t size;
+    char name[0];
+} boot_module_t;
+
+#endif

--- a/kernel/kernel/drivers/console/console.c
+++ b/kernel/kernel/drivers/console/console.c
@@ -69,7 +69,7 @@ void console_write_char(u32_t character)
         characters_per_line = vidmode.width / (get_character_width() + 1);
         current_x = 0;
         current_y = 0;
-        screen_buffer = calloc(lines * (characters_per_line + 1), sizeof(u32_t), 1);
+        screen_buffer = malloc(lines * (characters_per_line + 1) * sizeof(u32_t), 1);
         *screen_buffer = 0;
     }
     if (character == '\n')

--- a/kernel/kernel/main.c
+++ b/kernel/kernel/main.c
@@ -26,6 +26,7 @@ void main(void)
     puts("Primary module:");
     boot_module_t *boot_module = get_boot_module(0);
     puts(boot_module->name);
+    putnum64(boot_module->start, 10);
     for (size_t i = 0; i < boot_module->size; i ++) {
         putchar(((char*)boot_module->start)[i]);
     }

--- a/kernel/kernel/main.c
+++ b/kernel/kernel/main.c
@@ -5,25 +5,33 @@
 #include <time.h>
 #include <memory/map.h>
 
-void thread_start (void* arg)
+#include <modules.h>
+
+void thread_start(void *arg)
 {
-    loop:
+loop:
     goto loop;
 }
 
-void main (void)
+void main(void)
 {
-    initialise_drivers (0);
+    initialise_drivers(0);
     puts("Welcome to Micos");
-    putchar ('\n');
-    initialise_drivers (1);
-    initialise_drivers (2);
-    initialise_drivers (3);
+    putchar('\n');
+    initialise_drivers(1);
+    initialise_drivers(2);
+    initialise_drivers(3);
     thread_t thread_id;
     create_thread(&thread_id, thread_start, "a", "Initial kernel thread");
-    __asm__ ("sti");
-    putchar ('\n');
-    puts ("completed initialisation");    
-    loop:
+    puts("Primary module:");
+    boot_module_t *boot_module = get_boot_module(0);
+    puts(boot_module->name);
+    for (size_t i = 0; i < boot_module->size; i ++) {
+        putchar(((char*)boot_module->start)[i]);
+    }
+    __asm__("sti");
+    putchar('\n');
+    puts("completed initialisation");
+loop:
     goto loop;
 }


### PR DESCRIPTION
This allows the kernel to print out the contents of the first module passed by the boot loader. This will be useful for things like initramfses which can be passed to the kernel as modules.