### PR TITLE
Stack smash protector

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -13,7 +13,7 @@ AS=clang
 INCLUDEARGS=-I "$(CURDIR)/include" -I "$(CURDIR)/arch/$(ARCH)/include"
 
 AFLAGS=-target $(ARCH)-unknown-none-gnu -ffreestanding $(INCLUDEARGS)
-CFLAGS=-target $(ARCH)-unknown-none-gnu -ffreestanding -O2 -std=c11 $(INCLUDEARGS) -Wall -mcmodel=large
+CFLAGS=-target $(ARCH)-unknown-none-gnu -ffreestanding -O2 -std=c11 $(INCLUDEARGS) -Wall -mcmodel=large -fstack-protector-strong
 EXTERNALLDFLAGS=-relocatable
 
 include $(CURDIR)/arch/$(ARCH)/Make.properties

--- a/kernel/arch/x86_64/init/finale.S
+++ b/kernel/arch/x86_64/init/finale.S
@@ -38,7 +38,7 @@ shrq $16, %rdx
 xorq %rdx, %rax
 movabsq $0xF73A92C11C29A37F, %r8
 xorq %r8, %rax
-movq %rax, __stack_chk_guard
+movabsq %rax, __stack_chk_guard
 
 /*Early kernel setup and main kernel code*/
 movabsq $main, %rax

--- a/kernel/arch/x86_64/init/finale.S
+++ b/kernel/arch/x86_64/init/finale.S
@@ -29,11 +29,28 @@ movw %ax, %ss
 /*Set the new stack*/
 movabsq $stack_top, %rsp
 
+/*Stack smash protector setup*/
+/*Get a (random) number*/
+rdtsc /*As random as possible here*/
+shlq $32, %rax
+orq %rdx, %rax
+shrq $16, %rdx
+xorq %rdx, %rax
+movabsq $0xF73A92C11C29A37F, %r8
+xorq %r8, %rax
+movq %rax, __stack_chk_guard
+
 /*Early kernel setup and main kernel code*/
 movabsq $main, %rax
 pushq %rax /*arch_init returns to the start of main*/
 movabsq $arch_init, %rax
 jmpq * %rax
+
+.data
+
+.globl __stack_chk_guard
+__stack_chk_guard:
+.quad 0 /*initialised at runtime*/
 
 .bss
 

--- a/kernel/kernel/Makefile
+++ b/kernel/kernel/Makefile
@@ -7,6 +7,7 @@ STEPS+=error/error_screen.o
 STEPS+=task/registry.o
 STEPS+=strings/strops.o
 STEPS+=memory/memops.o
+STEPS+=stack/protector.o
 
 Micos.build: $(STEPS)
 	$(LD) $(LDFLAGS) $^ -o $@

--- a/kernel/kernel/stack/protector.c
+++ b/kernel/kernel/stack/protector.c
@@ -1,0 +1,3 @@
+#include <error.h>
+
+_Noreturn void __stack_chk_fail(void) { fatal_error("Stack smash detected"); }


### PR DESCRIPTION
The stack smash protector (or just stack protector) is a compiler feature which detects buffer overruns on the stack. It creates a special stack variable, which is initialised to a number determined at runtime, and checks if has changed anywhere in the function. If it has, it calls a failier handler because the stack was corrupted. 
This enables this feature.