### PR TITLE
Revert alignment for malloc

### DIFF
--- a/kernel/arch/x86_64/kernel/multiboot/mbi.c
+++ b/kernel/arch/x86_64/kernel/multiboot/mbi.c
@@ -76,7 +76,7 @@ void scan_mbi() {
     u32_t size = module_tag->end - module_tag->start;
     void *module_data = map_physical_address((void *)module_tag->start, size);
     int name_size = strlen(module_tag->name);
-    boot_module_t *module = malloc(sizeof(boot_module_t) + name_size + 1, 4096);
+    boot_module_t *module = malloc(sizeof(boot_module_t) + name_size + 1);
     strcpy(module->name, module_tag->name);
     module->size = size;
     module->start = module_data;

--- a/kernel/arch/x86_64/kernel/multiboot/mbi.c
+++ b/kernel/arch/x86_64/kernel/multiboot/mbi.c
@@ -82,5 +82,4 @@ void scan_mbi() {
     module->start = module_data;
     boot_modules[i] = module;
   }
-  free((void *)mbi_ptr);
 }

--- a/kernel/arch/x86_64/kernel/paging/malloc/alloc.c
+++ b/kernel/arch/x86_64/kernel/paging/malloc/alloc.c
@@ -6,7 +6,7 @@
 
 void *malloc(size_t size) {
   size = (size + 4095) / 4096 * 4096; // align ed
-  void *ptr = reserve_block(size, 4096);
+  void *ptr = reserve_block(size);
   u8_t *working_ptr = ptr;
   for (int i = 0; i < size; i += 4096) {
     map_page(allocate_frame(), (u64_t)(working_ptr + i) >> 12,
@@ -21,7 +21,7 @@ void *malloc(size_t size) {
 
 void *malloc_uncacheable(size_t size) {
   size = (size + 4095) / 4096 * 4096; // align ed
-  void *ptr = reserve_block(size, 4096);
+  void *ptr = reserve_block(size);
   u8_t *working_ptr = ptr;
   for (int i = 0; i < size; i += 4096) {
     map_page(allocate_frame(), (u64_t)(working_ptr + i) >> 12,

--- a/kernel/arch/x86_64/kernel/paging/malloc/alloc.c
+++ b/kernel/arch/x86_64/kernel/paging/malloc/alloc.c
@@ -4,14 +4,13 @@
 
 #include "blocks.h"
 
-void *malloc(size_t size, unsigned int alignment) {
-  size = (size + alignment - 1 + 8); // align ed
-  void *ptr = reserve_block(size, alignment);
+void *malloc(size_t size) {
+  size = (size + 4095) / 4096 * 4096; // align ed
+  void *ptr = reserve_block(size, 4096);
   u8_t *working_ptr = ptr;
-  u64_t first_page = ((u64_t)working_ptr + 4095) / 4096 * 4096;
-  u64_t last_page = first_page + (size + 4095) / 4096 * 4096;
-  for (u64_t i = first_page; i <= last_page; i += 4096) {
-    map_page(allocate_frame(), i >> 12, PAGE_PRESENT | PAGE_WRITABLE);
+  for (int i = 0; i < size; i += 4096) {
+    map_page(allocate_frame(), (u64_t)(working_ptr + i) >> 12,
+             PAGE_PRESENT | PAGE_WRITABLE);
   }
   working_ptr = ptr;
   *((size_t *)working_ptr) = size;
@@ -20,14 +19,12 @@ void *malloc(size_t size, unsigned int alignment) {
   return ptr;
 }
 
-void *malloc_uncacheable(size_t size, unsigned int alignment) {
-  size = (size + alignment - 1 + 8); // aligned
-  void *ptr = reserve_block(size, alignment);
+void *malloc_uncacheable(size_t size) {
+  size = (size + 4095) / 4096 * 4096; // align ed
+  void *ptr = reserve_block(size, 4096);
   u8_t *working_ptr = ptr;
-  u64_t first_page = ((u64_t)working_ptr + 4095) / 4096 * 4096;
-  u64_t last_page = first_page + (size + 4095) / 4096 * 4096;
-  for (u64_t i = first_page; i <= last_page; i += 4096) {
-    map_page(allocate_frame(), i >> 12,
+  for (int i = 0; i < size; i += 4096) {
+    map_page(allocate_frame(), (u64_t)(working_ptr + i) >> 12,
              PAGE_PRESENT | PAGE_WRITABLE | PAGE_CACHE_DISABLE);
   }
   working_ptr = ptr;

--- a/kernel/arch/x86_64/kernel/paging/malloc/blocks.c
+++ b/kernel/arch/x86_64/kernel/paging/malloc/blocks.c
@@ -40,21 +40,20 @@ void create_block(memblock_t new_block) {
   free_lock(&block_lock);
 }
 
-void *reserve_block(size_t size, unsigned int alignment) {
+void *reserve_block(size_t size) {
   synchronise(&block_lock);
   if (!prepared) {
     memblocks_init();
   }
   for (int i = start; i < end; i++) {
     memblock_t block = block_buffer[i];
-    if ((u64_t)(((u64_t)block.start + alignment - 1) / alignment * alignment -
-                (u64_t)block.end) >= size) {
-      void *result = block.start;
-      block.start += (size + alignment - 1) / alignment * alignment;
-      block_buffer[i] = block;
-      free_lock(&block_lock);
-      return result;
-    }
+            if ((u64_t)(block.start - block.end) >= size) {
+            void * result = block.start;
+            block.start += size;
+            block_buffer [i] = block;
+            free_lock(&block_lock);
+            return result;
+        }
   }
   free_lock(&block_lock);
   return 0;

--- a/kernel/arch/x86_64/kernel/paging/malloc/blocks.h
+++ b/kernel/arch/x86_64/kernel/paging/malloc/blocks.h
@@ -8,10 +8,10 @@ typedef struct {
   void* end;
 } memblock_t;
 
+// Adds the block to the block pool
 void create_block(memblock_t block);
-// Reserves the block from the block pool. The block will have enough space to
-// fit the specified size, + any required alignment bytes.
-void* reserve_block(size_t size, unsigned int alignment);
+// Reserves the block from the block pool
+void* reserve_block(size_t size);
 void clean_blocks();
 
 #endif

--- a/kernel/arch/x86_64/kernel/paging/malloc/free.c
+++ b/kernel/arch/x86_64/kernel/paging/malloc/free.c
@@ -1,3 +1,4 @@
+#include <error.h>
 #include <page_tables.h>
 #include <paging/frames.h>
 
@@ -5,14 +6,19 @@
 
 void free(void *ptr) {
   u8_t *working_ptr = ptr;
-  working_ptr -= sizeof(size_t);  // overhead
+  working_ptr -= sizeof(size_t); // overhead
+  if ((u64_t)working_ptr % 4096) {
+    fatal_error("Unaligned pointer cannot be freed");
+  }
   size_t memblock_size = *((size_t *)working_ptr);
+  if (memblock_size % 4096) {
+    fatal_error("Corrupted memory passed to free");
+  }
   clean_blocks();
   create_block(
       (memblock_t){.start = working_ptr, .end = working_ptr + memblock_size});
   clean_blocks();
-  for (u64_t address =
-           (u64_t)(working_ptr + sizeof(size_t) + 4095) / 4096 * 4096;
+  for (u64_t address = (u64_t)working_ptr;
        address < (u64_t)working_ptr + memblock_size; address += 4096) {
     unmap_page(address / 4096);
   }

--- a/kernel/arch/x86_64/kernel/paging/mapping.c
+++ b/kernel/arch/x86_64/kernel/paging/mapping.c
@@ -41,7 +41,7 @@ void unmap_page(u64_t page_index) {
 
 void *map_physical_address(void *address, size_t size) {
   u64_t pages = (size + 4095) / 4096;
-  void *ptr = malloc(pages * 4096, 4096);
+  void *ptr = malloc(pages * 4096);
   u64_t frame_index = ((u64_t)address) / 4096;
   u64_t page_index = ((u64_t)ptr) / 4096;
   reserve_frames(frame_index, frame_index + pages - 1);

--- a/kernel/arch/x86_64/kernel/thread/thread.c
+++ b/kernel/arch/x86_64/kernel/thread/thread.c
@@ -7,12 +7,12 @@
 
 int create_thread(thread_t *thread, void (*start)(void *), void *arg,
                   const char *name) {
-  int8_t *stack = malloc(THREAD_STACK_SIZE, 1);
+  u8_t *stack = malloc(THREAD_STACK_SIZE);
   if (stack == 0) {
     return 1;
   }
   stack += THREAD_STACK_SIZE;
-  task_state *task = malloc(sizeof(task_state), 1);
+  task_state *task = malloc(sizeof(task_state));
   if (task == 0) {
     return 1;
   }

--- a/kernel/fs/vfs/directory.c
+++ b/kernel/fs/vfs/directory.c
@@ -5,7 +5,7 @@
 file_t *virtual_directory_list(file_t *file) { return (file_t *)file->data; }
 
 file_t *virtual_directory_mkdir(file_t *file, const char *name) {
-  file_t *directory = calloc(1, sizeof(file_t), 1);
+  file_t *directory = calloc(1, sizeof(file_t));
   directory->name = name;
   directory->type = FILE_DIRECTORY;
   directory->get_first_child = &virtual_directory_list;

--- a/kernel/include/malloc.h
+++ b/kernel/include/malloc.h
@@ -3,9 +3,9 @@
 
 #include <stdint.h>
 
-void* malloc(size_t size, unsigned int alignment);
+void* malloc(size_t size);
 void free(void* ptr);
 
-void* calloc(size_t number, size_t size, unsigned int alignment);
+void* calloc(size_t number, size_t size);
 
 #endif

--- a/kernel/include/memory.h
+++ b/kernel/include/memory.h
@@ -6,6 +6,6 @@
 void* map_physical_address(void* physical_address, size_t size);
 void* map_physical_address_uncached(void* physical_address, size_t size);
 
-void* malloc_uncacheable(size_t size, unsigned int alignment);
+void* malloc_uncacheable(size_t size);
 
 #endif

--- a/kernel/kernel/drivers/console/console.c
+++ b/kernel/kernel/drivers/console/console.c
@@ -65,7 +65,7 @@ void console_write_char(u32_t character) {
     current_x = 0;
     current_y = 0;
     screen_buffer =
-        malloc(lines * (characters_per_line + 1) * sizeof(u32_t), 1);
+        malloc(lines * (characters_per_line + 1) * sizeof(u32_t));
     *screen_buffer = 0;
   }
   if (character == '\n') {

--- a/kernel/kernel/drivers/pci/pci_table.c
+++ b/kernel/kernel/drivers/pci/pci_table.c
@@ -5,10 +5,10 @@
 
 static size_t pci_table_size = 1024;
 static size_t pci_entries = 0;
-static pci_device_t* pci_table;
+static pci_device_t *pci_table;
 
 void init_pci_table() {
-  pci_table = malloc(pci_table_size * sizeof(pci_device_t), 1);
+  pci_table = malloc(pci_table_size * sizeof(pci_device_t));
 }
 
 void register_pci_device(pci_device_t device) {
@@ -16,18 +16,18 @@ void register_pci_device(pci_device_t device) {
   pci_entries++;
 }
 
-void register_pci_driver(int (*condition)(common_pci_header*),
-                         int (*init)(pci_device_t*)) {
-  common_pci_header* pci_header = malloc(sizeof(common_pci_header), 1);
+void register_pci_driver(int (*condition)(common_pci_header *),
+                         int (*init)(pci_device_t *)) {
+  common_pci_header *pci_header = malloc(sizeof(common_pci_header));
   for (size_t i = 0; i < pci_entries; i++) {
-    pci_device_t* device = pci_table + i;
-    *((u32_t*)pci_header + 0) =
+    pci_device_t *device = pci_table + i;
+    *((u32_t *)pci_header + 0) =
         pci_read_configuration_register(device->bus, device->dev, 0, 0);
-    *((u32_t*)pci_header + 1) =
+    *((u32_t *)pci_header + 1) =
         pci_read_configuration_register(device->bus, device->dev, 0, 4);
-    *((u32_t*)pci_header + 2) =
+    *((u32_t *)pci_header + 2) =
         pci_read_configuration_register(device->bus, device->dev, 0, 8);
-    *((u32_t*)pci_header + 3) =
+    *((u32_t *)pci_header + 3) =
         pci_read_configuration_register(device->bus, device->dev, 0, 12);
     if (!condition(pci_header)) {
       init(device);

--- a/kernel/kernel/memory/memops.c
+++ b/kernel/kernel/memory/memops.c
@@ -1,8 +1,8 @@
 #include <malloc.h>
 #include <strings.h>
 
-void *calloc(size_t number, size_t size, unsigned int alignment) {
-  void *memory = malloc(number * size, alignment);
+void *calloc(size_t number, size_t size) {
+  void *memory = malloc(number * size);
   memset(memory, 0, size * number);
   return memory;
 }


### PR DESCRIPTION
#43 Added a new parameter to malloc: an alignment. This was used to work out weather it was possible to put the new memory in a new page or in an old page with something else in it, or overlapping pages. This was a good idea, but it was causing memory leaks. To help stop this from happening, this is now being reverted.