### PR TITLE
Fix tripple fault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ else
 	@mkdir -p $(DIR)/boot/grub
 	@rm -f $(DIR)/boot/Micos
 	cp build/Micos $(DIR)/boot/Micos
+	@strip $(DIR)/boot/Micos
 	@rm -f $(DIR)/boot/grub/grub.cfg
 	cp grub/grub.cfg $(DIR)/boot/grub/grub.cfg
 endif

--- a/debugging/qemu-headless.gdb
+++ b/debugging/qemu-headless.gdb
@@ -1,2 +1,2 @@
-add-symbol-file build/Micos 0x100000
+file build/Micos
 target remote | qemu-system-x86_64 -S -gdb stdio -cdrom build/Micos.iso -display none

--- a/debugging/qemu.gdb
+++ b/debugging/qemu.gdb
@@ -1,2 +1,2 @@
-add-symbol-file build/Micos 0x100000
+file build/Micos
 target remote | qemu-system-x86_64 -S -gdb stdio -cdrom build/Micos.iso

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -13,7 +13,7 @@ AS=clang
 INCLUDEARGS=-I "$(CURDIR)/include" -I "$(CURDIR)/arch/$(ARCH)/include"
 
 AFLAGS=-target $(ARCH)-unknown-none-gnu -ffreestanding $(INCLUDEARGS)
-CFLAGS=-target $(ARCH)-unknown-none-gnu -ffreestanding -O2 -std=c11 $(INCLUDEARGS) -Wall -mcmodel=large -fstack-protector-strong
+CFLAGS=-target $(ARCH)-unknown-none-gnu -ffreestanding -O2 -std=c11 $(INCLUDEARGS) -Wall -mcmodel=large -fstack-protector-strong -fno-omit-frame-pointer -g
 EXTERNALLDFLAGS=-relocatable
 
 include $(CURDIR)/arch/$(ARCH)/Make.properties

--- a/kernel/arch/x86_64/kernel/multiboot/mbi.c
+++ b/kernel/arch/x86_64/kernel/multiboot/mbi.c
@@ -5,6 +5,7 @@
 #include <modules.h>
 #include <multiboot.h>
 #include <strings.h>
+#include <paging/frames.h>
 
 static frame_buffer_info_t frame_buffer = {
     .buffer = 0, .width = 0, .height = 0};
@@ -68,8 +69,9 @@ void scan_mbi() {
     process_tag((mbi_tag_t *)mbi_ptr);
     mbi_ptr += ((tag.size + MBI_ALIGNMENT - 1) / 8) * 8;
   }
-  mbi_ptr = (u64_t)map_physical_address((void *)multiboot_data_ptr,
-                                        *((u32_t *)multiboot_data_ptr));
+  u32_t mbi_size = *((u32_t *)multiboot_data_ptr);
+  reserve_frames(mbi_ptr / 4096, (mbi_ptr + mbi_size + 4095) / 4096);
+  mbi_ptr = (u64_t)map_physical_address((void *)multiboot_data_ptr, mbi_size);
   for (int i = 0; i < number_of_modules; i++) {
     mbi_boot_module_tag_t *module_tag =
         (mbi_boot_module_tag_t *)(mbi_ptr + module_offsets[i]);

--- a/kernel/arch/x86_64/kernel/paging/frames.c
+++ b/kernel/arch/x86_64/kernel/paging/frames.c
@@ -55,6 +55,9 @@ u64_t allocate_frame() { return allocate_frames(1); }
 
 void return_frames(u64_t index, u64_t number_of_frames) {
   synchronise(&frame_lock);
+  if (free_memory.number_of_blocks == 0) {
+    init();
+  }
   int i = 0;
   memory_block_t *tmp = &(free_memory.blocks[i]);
   // Try to find a block which is consecutive with the frame
@@ -96,6 +99,9 @@ void reserve_frames(u64_t start_index, u64_t end_index) {
     fatal_error("Start block index > end index");
   }
   synchronise(&frame_lock);
+  if (free_memory.number_of_blocks == 0) {
+    init();
+  }
   for (int i = 0; i < free_memory.number_of_blocks; i++) {
     memory_block_t *block = &(free_memory.blocks[i]);
     u64_t block_start = (u64_t)block->base / 4096;

--- a/kernel/arch/x86_64/kernel/paging/frames.c
+++ b/kernel/arch/x86_64/kernel/paging/frames.c
@@ -78,7 +78,7 @@ void return_frames(u64_t index, u64_t number_of_frames) {
   // The frame is not consecutive with any blocks
   i = 0;
   tmp = &(free_memory.blocks[i]);
-  while (tmp->length != 0) {
+  while (tmp->length != 0 && i < free_memory.number_of_blocks) {
     i++;
   }
   if (i >= 1024) {
@@ -123,8 +123,10 @@ void reserve_frames(u64_t start_index, u64_t end_index) {
       block->length = (block_end - start_index) * 4096;
     } else if (start_index >= block_start && end_index <= block_end) {
       block->length = 0;
+      free_lock(&frame_lock);
       return_frames(block_start, start_index - block_start);
       return_frames(end_index, block_end - end_index);
+      synchronise(&frame_lock);
     }
   }
   free_lock(&frame_lock);

--- a/kernel/arch/x86_64/kernel/paging/malloc/alloc.c
+++ b/kernel/arch/x86_64/kernel/paging/malloc/alloc.c
@@ -8,7 +8,7 @@ void *malloc(size_t size) {
   size = (size + 4095) / 4096 * 4096; // align ed
   void *ptr = reserve_block(size);
   u8_t *working_ptr = ptr;
-  for (int i = 0; i < size; i += 4096) {
+  for (u64_t i = 0; i < size; i += 4096) {
     map_page(allocate_frame(), (u64_t)(working_ptr + i) >> 12,
              PAGE_PRESENT | PAGE_WRITABLE);
   }
@@ -23,7 +23,7 @@ void *malloc_uncacheable(size_t size) {
   size = (size + 4095) / 4096 * 4096; // align ed
   void *ptr = reserve_block(size);
   u8_t *working_ptr = ptr;
-  for (int i = 0; i < size; i += 4096) {
+  for (u64_t i = 0; i < size; i += 4096) {
     map_page(allocate_frame(), (u64_t)(working_ptr + i) >> 12,
              PAGE_PRESENT | PAGE_WRITABLE | PAGE_CACHE_DISABLE);
   }

--- a/kernel/arch/x86_64/kernel/paging/mapping.c
+++ b/kernel/arch/x86_64/kernel/paging/mapping.c
@@ -41,7 +41,7 @@ void unmap_page(u64_t page_index) {
 
 void *map_physical_address(void *address, size_t size) {
   u64_t pages = (size + 4095) / 4096;
-  void *ptr = malloc(pages * 4096);
+  void *ptr = malloc(pages * 4096); 
   u64_t frame_index = ((u64_t)address) / 4096;
   u64_t page_index = ((u64_t)ptr) / 4096;
   reserve_frames(frame_index, frame_index + pages - 1);

--- a/kernel/drivers/display/display.c
+++ b/kernel/drivers/display/display.c
@@ -14,6 +14,9 @@ static video_mode vidmode;
 void display_init(void) {
   display_driver.init = 0;
   frame_buffer = *get_frame_buffer();
+  if (frame_buffer.buffer == 0) {
+    return; // No display
+  }
   frame_buffer.buffer = map_physical_address(
       frame_buffer.buffer,
       frame_buffer.width * frame_buffer.pitch * sizeof(frame_buffer_cell));

--- a/kernel/fonts/renderer/psf.c
+++ b/kernel/fonts/renderer/psf.c
@@ -26,6 +26,9 @@ void initialise_font() {
 
 void render_character(int x, int y, u32_t code_point, display_pixel foreground,
                       display_pixel background) {
+                        if (glyph_pointer == 0) {
+                          return; // Font not initialised
+                        }
   code_point = code_point < font_start.number_glyphs ? code_point : 0;
   u8_t* glyph = glyph_pointer + code_point * font_start.glyph_bytes - 1;
   int screen_offset_y = y * font_start.height;


### PR DESCRIPTION
After #56, the kernel was tripple faulting on uefi systems. This was due to overwriting of the mbi and the kernel was attempting to allocate four gigabytes for 100 bytes of boot module. 
This fixes this.