### PR TITLE
Read tar file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,20 @@ $(KERNEL):
 	@mkdir -p build
 	@ mv $(KERNEL) build
 
+initramfs:
+	@rm -rf build/initramfs/*
+	@cp -r init/config/* build/initramfs/
+	@cd build/initramfs && tar -cf ../initramfs.tar *
+
 install:
 ifeq (,$(DIR))
 	@echo $(DIR)
 	@echo "please provide a valid path with DIR=/path/to/install/dir"
 else
 	@mkdir -p $(DIR)/boot/grub
-	@rm -f $(DIR)/boot/Micos
 	cp build/Micos $(DIR)/boot/Micos
 	@strip $(DIR)/boot/Micos
-	@rm -f $(DIR)/boot/grub/grub.cfg
+	cp build/initramfs.tar $(DIR)/boot/initramfs.tar
 	cp grub/grub.cfg $(DIR)/boot/grub/grub.cfg
 endif
 
@@ -26,11 +30,12 @@ efiimage:
 	@mkdir -p build/efi
 	@grub-mkimage -O x86_64-efi -p /boot/grub -o build/efi/BOOTX64.EFI normal part_msdos fat part_gpt all_video multiboot2
 
-iso: $(KERNEL) efiimage
+iso: $(KERNEL) initramfs efiimage
 	@rm -rf build/grub
 	@mkdir -p build/grub/boot
 	@cp build/Micos build/grub/boot/Micos
 	@strip build/grub/boot/Micos
+	@cp build/initramfs.tar build/grub/boot/initramfs.tar
 	@cp -r grub build/grub/boot/grub
 	@mkdir -p build/grub/EFI/BOOT
 	@cp build/efi/BOOTX64.EFI build/grub/EFI/BOOT/BOOTX64.EFI
@@ -38,3 +43,5 @@ iso: $(KERNEL) efiimage
 
 clean:
 	@$(MAKE) -s -C kernel clean BASEDIR=kernel
+	@echo "Clean build"
+	@rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ $(KERNEL):
 
 initramfs:
 	@rm -rf build/initramfs/*
+	@mkdir -p build/initramfs
 	@cp -r init/config/* build/initramfs/
 	@cd build/initramfs && tar -cf ../initramfs.tar *
 

--- a/grub/grub.cfg
+++ b/grub/grub.cfg
@@ -3,6 +3,6 @@ set default=0
 
 menuentry "Micos" {
 	multiboot2 /boot/Micos
-	module2 /boot/grub/grub.cfg test
+	module2 /boot/initramfs.tar initramfs
 	boot
 }

--- a/init/config/init.conf
+++ b/init/config/init.conf
@@ -1,0 +1,1 @@
+#Configuration file goes here

--- a/kernel/arch/x86_64/kernel/memory/memops.S
+++ b/kernel/arch/x86_64/kernel/memory/memops.S
@@ -35,23 +35,3 @@ movq %rdx, %rcx
 rep movsb /*and the rest*/
 popq %rax
 retq
-
-.globl memcmp
-memcmp:
-movq %rdx, %rcx
-shrq $3, %rcx
-andq $7, %rdx
-rep cmpsq
-jnz 1f
-movq %rdx, %rcx
-rep cmpsb
-1:
-jz 1f
-jmp 2f
-1:
-movq $0, %rax
-jmp 1f
-2:
-movq $1, %rax
-1:
-retq

--- a/kernel/fs/Makefile
+++ b/kernel/fs/Makefile
@@ -1,4 +1,5 @@
 STEPS:=vfs/vfs.o vfs/directory.o
+STEPS+=initramfs/initramfs.o
 
 Micos.build: $(STEPS)
 	$(LD) $(LDFLAGS) $^ -o $@

--- a/kernel/fs/initramfs/initramfs.c
+++ b/kernel/fs/initramfs/initramfs.c
@@ -10,27 +10,24 @@ static inline size_t octal_to_binary(unsigned char *octal, size_t size) {
   return result;
 }
 
-size_t initramfs_read(unsigned char* initramfs, size_t initramfs_size, const char* file_name, unsigned char** data) {
+size_t initramfs_read(unsigned char *initramfs, size_t initramfs_size,
+                      const char *file_name, unsigned char **data) {
   // Preliminary checks: is this a valid tar file?
   if (initramfs_size < 512) {
-      // Too small to be a tar file
-    return 0;
-  }
-  if (memcmp(initramfs + 257, "ustar", 5)) {
-      // No "ustar" signature found
+    // Too small to be a tar file
     return 0;
   }
   size_t offset = 0;
-  while (offset < initramfs_size && !memcmp(initramfs + offset + 257, "ustar", 5)) {
+  while (!memcmp(initramfs + offset + 257, "ustar", 5)) {
     size_t file_size = octal_to_binary(initramfs + offset + 124, 11);
     unsigned char file_type = initramfs[offset + 156];
     if (file_type == '0' || file_type == 0) {
-        // Regular file
-        if(!strcmp(file_name, initramfs + offset)) {
-            // Found it!
-            *data = initramfs + offset + 512;
-            return file_size;
-        }
+      // Regular file
+      if (!strcmp(file_name, initramfs + offset)) {
+        // Found it!
+        *data = initramfs + offset + 512;
+        return file_size;
+      }
     }
     offset += (file_size + 512 + 511) / 512 * 512;
   }

--- a/kernel/fs/initramfs/initramfs.c
+++ b/kernel/fs/initramfs/initramfs.c
@@ -1,0 +1,1 @@
+#include <fs/initramfs.h>

--- a/kernel/fs/initramfs/initramfs.c
+++ b/kernel/fs/initramfs/initramfs.c
@@ -1,1 +1,39 @@
 #include <fs/initramfs.h>
+#include <strings.h>
+
+static inline size_t octal_to_binary(unsigned char *octal, size_t size) {
+  size_t result = 0;
+  for (size_t i = 0; i < size; i++) {
+    result *= 8;
+    result += octal[i] - '0';
+  }
+  return result;
+}
+
+size_t initramfs_read(unsigned char* initramfs, size_t initramfs_size, const char* file_name, unsigned char** data) {
+  // Preliminary checks: is this a valid tar file?
+  if (initramfs_size < 512) {
+      // Too small to be a tar file
+    return 0;
+  }
+  if (memcmp(initramfs + 257, "ustar", 5)) {
+      // No "ustar" signature found
+    return 0;
+  }
+  size_t offset = 0;
+  while (offset < initramfs_size && !memcmp(initramfs + offset + 257, "ustar", 5)) {
+    size_t file_size = octal_to_binary(initramfs + offset + 124, 11);
+    unsigned char file_type = initramfs[offset + 156];
+    if (file_type == '0' || file_type == 0) {
+        // Regular file
+        if(!strcmp(file_name, initramfs + offset)) {
+            // Found it!
+            *data = initramfs + offset + 512;
+            return file_size;
+        }
+    }
+    offset += (file_size + 512 + 511) / 512 * 512;
+  }
+  // Didn't find it.
+  return 0;
+}

--- a/kernel/include/fs/initramfs.h
+++ b/kernel/include/fs/initramfs.h
@@ -1,0 +1,9 @@
+#ifndef _FS_INITRAMFS_H
+#define _FS_INITRAMFS_H  
+
+#include <stdint.h>
+
+// Gets the contents of the specified file in the initramfs, returning the size or 0 if the file could not be found, and putting a pointer to the data in data.
+size_t initramfs_read(unsigned char* initramfs, const char* file_name, unsigned char** data);
+
+#endif

--- a/kernel/include/fs/initramfs.h
+++ b/kernel/include/fs/initramfs.h
@@ -4,6 +4,6 @@
 #include <stdint.h>
 
 // Gets the contents of the specified file in the initramfs, returning the size or 0 if the file could not be found, and putting a pointer to the data in data.
-size_t initramfs_read(unsigned char* initramfs, const char* file_name, unsigned char** data);
+size_t initramfs_read(unsigned char* initramfs, const size_t initramfs_size, const char* file_name, unsigned char** data);
 
 #endif

--- a/kernel/kernel/main.c
+++ b/kernel/kernel/main.c
@@ -1,12 +1,31 @@
 #include <drivers/init.h>
 #include <error.h>
-#include <fs/fs.h>
+#include <fs/initramfs.h>
 #include <memory/map.h>
+#include <modules.h>
 #include <stdio.h>
 #include <thread.h>
 #include <time.h>
 
 void thread_start(void *arg) {
+  // Find the init.conf file
+  boot_module_t *module;
+  char *init_conf = 0;
+  size_t init_conf_size = 0;
+  for (int i = 0; (module = get_boot_module(i)); i++) {
+    init_conf_size =
+        initramfs_read(module->start, module->size, "init.conf", &init_conf);
+    if (init_conf_size) {
+      break;
+    }
+  }
+  if (init_conf) {
+    puts("Found init.conf:");
+    for (size_t i = 0; i < init_conf_size; i++) {
+      putchar(init_conf[i]);
+    }
+    putchar('\n');
+  }
 loop:
   goto loop;
 }

--- a/kernel/kernel/memory/memops.c
+++ b/kernel/kernel/memory/memops.c
@@ -6,3 +6,14 @@ void *calloc(size_t number, size_t size) {
   memset(memory, 0, size * number);
   return memory;
 }
+
+int memcmp(void *a, void *b, size_t size) {
+  const char *a_ptr = (const char *)a;
+  const char *b_ptr = (const char *)b;
+  for (int i = 0; i < size; i++) {
+    if (a_ptr[i] != b_ptr[i]) {
+      return a_ptr[i] - b_ptr[i];
+    }
+  }
+  return 0;
+}


### PR DESCRIPTION
This feature creates a tar file (initramfs.tar) which is passed as the multiboot module to the kernel. It currently contains just one file: init.conf (a template). 
The code reads this init.conf using a new initramfs_read function and prints out its contents to the screen.