### PR TITLE
Make map page allocate page tables

### DIFF
--- a/kernel/arch/x86_64/include/page_tables.h
+++ b/kernel/arch/x86_64/include/page_tables.h
@@ -23,11 +23,11 @@ void invalidate_page_cache(u64_t page_index);
 // because of recursive mapping, these special addresses point to the various
 // parts of the page tables
 #define PML4_VIRTUAL_ADDRESS 01777777777777777770000ULL
-#define PDP_VIRTUAL_ADDRESS(I) ((I)*010000ULL | 01777777777777770000000ULL)
-#define PDD_VIRTUAL_ADDRESS(I, J)                                              \
-  ((I)*010000ULL | (J)*010000000ULL | 01777777777770000000000ULL)
-#define PAGE_TABLE_VIRTUAL_ADDRESS(I, J, K)                                    \
-  ((I)*010000ULL | (J)*010000000ULL | (K)*010000000000ULL |                    \
+#define PDP_VIRTUAL_ADDRESS(PDP) ((PDP)*010000ULL | 01777777777777770000000ULL)
+#define PDD_VIRTUAL_ADDRESS(PDD, PDP)                                          \
+  ((PDD)*010000ULL | (PDP)*010000000ULL | 01777777777770000000000ULL)
+#define PAGE_TABLE_VIRTUAL_ADDRESS(PAGE_TABLE, PDD, PDP)                       \
+  ((PAGE_TABLE)*010000ULL | (PDD)*010000000ULL | (PDP)*010000000000ULL |       \
    01777777770000000000000ULL)
 
 #endif

--- a/kernel/arch/x86_64/include/page_tables.h
+++ b/kernel/arch/x86_64/include/page_tables.h
@@ -22,11 +22,12 @@ void invalidate_page_cache(u64_t page_index);
 
 // because of recursive mapping, these special addresses point to the various
 // parts of the page tables
-#define PML4_VIRTUAL_ADDRESS 01777777777777777770000
-#define PDP_VIRTUAL_ADDRESS(I) (I * 010000 | 01777777777777770000000)
-#define PDD_VIRTUAL_ADDRESS(I, J) \
-  (I * 010000 | J * 010000000 | 01777777777770000000000)
-#define PAGE_TABLE_VIRTUAL_ADDRESS(I, J, K) \
-  (I * 010000ULL | J * 010000000ULL | K * 010000000000ULL | 01777777770000000000000ULL)
+#define PML4_VIRTUAL_ADDRESS 01777777777777777770000ULL
+#define PDP_VIRTUAL_ADDRESS(I) ((I)*010000ULL | 01777777777777770000000ULL)
+#define PDD_VIRTUAL_ADDRESS(I, J)                                              \
+  ((I)*010000ULL | (J)*010000000ULL | 01777777777770000000000ULL)
+#define PAGE_TABLE_VIRTUAL_ADDRESS(I, J, K)                                    \
+  ((I)*010000ULL | (J)*010000000ULL | (K)*010000000000ULL |                    \
+   01777777770000000000000ULL)
 
 #endif

--- a/kernel/arch/x86_64/kernel/paging/mapping.c
+++ b/kernel/arch/x86_64/kernel/paging/mapping.c
@@ -2,6 +2,7 @@
 #include <memory.h>
 #include <page_tables.h>
 #include <paging/frames.h>
+#include <strings.h>
 
 page_table_entry_t *locate_page_table_entry(u64_t page) {
   u16_t page_table_index = page % 512;
@@ -11,6 +12,19 @@ page_table_entry_t *locate_page_table_entry(u64_t page) {
   u16_t pdd = page % 512;
   page = page >> 9;
   u16_t pdp = page % 512;
+  if (((page_table_entry_t*)PML4_VIRTUAL_ADDRESS) [pdp] == 0) {
+    ((page_table_entry_t *)PML4_VIRTUAL_ADDRESS)[pdp] = allocate_frame() << 12 | PAGE_PRESENT | PAGE_WRITABLE;
+    memset((void*)PDP_VIRTUAL_ADDRESS(pdp), 0, 4096);
+  }
+  if (((page_table_entry_t*)PDP_VIRTUAL_ADDRESS(pdp))[pdd] == 0) {
+    ((page_table_entry_t*)PDP_VIRTUAL_ADDRESS(pdp))[pdd] = allocate_frame() << 12 | PAGE_PRESENT | PAGE_WRITABLE;
+    memset((void*)PDD_VIRTUAL_ADDRESS(pdp, pdd), 0, 4096);
+  }
+  if (((page_table_entry_t*)PDD_VIRTUAL_ADDRESS(pdp, pdd))[page_table] == 0) {
+    ((page_table_entry_t *)PDD_VIRTUAL_ADDRESS(pdp, pdd))[page_table] =
+        allocate_frame() << 12 | PAGE_PRESENT | PAGE_WRITABLE;
+    memset((void*)PAGE_TABLE_VIRTUAL_ADDRESS(pdp, pdd, page_table), 0, 4096);
+  }
   return ((page_table_entry_t *)PAGE_TABLE_VIRTUAL_ADDRESS(page_table, pdd,
                                                            pdp)) +
          page_table_index;

--- a/kernel/arch/x86_64/kernel/paging/mapping.c
+++ b/kernel/arch/x86_64/kernel/paging/mapping.c
@@ -18,12 +18,12 @@ page_table_entry_t *locate_page_table_entry(u64_t page) {
   }
   if (((page_table_entry_t*)PDP_VIRTUAL_ADDRESS(pdp))[pdd] == 0) {
     ((page_table_entry_t*)PDP_VIRTUAL_ADDRESS(pdp))[pdd] = allocate_frame() << 12 | PAGE_PRESENT | PAGE_WRITABLE;
-    memset((void*)PDD_VIRTUAL_ADDRESS(pdp, pdd), 0, 4096);
+    memset((void*)PDD_VIRTUAL_ADDRESS(pdd, pdp), 0, 4096);
   }
-  if (((page_table_entry_t*)PDD_VIRTUAL_ADDRESS(pdp, pdd))[page_table] == 0) {
+  if (((page_table_entry_t*)PDD_VIRTUAL_ADDRESS(pdd, pdp))[page_table] == 0) {
     ((page_table_entry_t *)PDD_VIRTUAL_ADDRESS(pdp, pdd))[page_table] =
         allocate_frame() << 12 | PAGE_PRESENT | PAGE_WRITABLE;
-    memset((void*)PAGE_TABLE_VIRTUAL_ADDRESS(pdp, pdd, page_table), 0, 4096);
+    memset((void*)PAGE_TABLE_VIRTUAL_ADDRESS(page_table, pdd, pdp), 0, 4096);
   }
   return ((page_table_entry_t *)PAGE_TABLE_VIRTUAL_ADDRESS(page_table, pdd,
                                                            pdp)) +

--- a/kernel/arch/x86_64/kernel/paging/mapping.c
+++ b/kernel/arch/x86_64/kernel/paging/mapping.c
@@ -12,18 +12,20 @@ page_table_entry_t *locate_page_table_entry(u64_t page) {
   u16_t pdd = page % 512;
   page = page >> 9;
   u16_t pdp = page % 512;
-  if (((page_table_entry_t*)PML4_VIRTUAL_ADDRESS) [pdp] == 0) {
-    ((page_table_entry_t *)PML4_VIRTUAL_ADDRESS)[pdp] = allocate_frame() << 12 | PAGE_PRESENT | PAGE_WRITABLE;
-    memset((void*)PDP_VIRTUAL_ADDRESS(pdp), 0, 4096);
-  }
-  if (((page_table_entry_t*)PDP_VIRTUAL_ADDRESS(pdp))[pdd] == 0) {
-    ((page_table_entry_t*)PDP_VIRTUAL_ADDRESS(pdp))[pdd] = allocate_frame() << 12 | PAGE_PRESENT | PAGE_WRITABLE;
-    memset((void*)PDD_VIRTUAL_ADDRESS(pdd, pdp), 0, 4096);
-  }
-  if (((page_table_entry_t*)PDD_VIRTUAL_ADDRESS(pdd, pdp))[page_table] == 0) {
-    ((page_table_entry_t *)PDD_VIRTUAL_ADDRESS(pdp, pdd))[page_table] =
+  if (((page_table_entry_t *)PML4_VIRTUAL_ADDRESS)[pdp] == 0) {
+    ((page_table_entry_t *)PML4_VIRTUAL_ADDRESS)[pdp] =
         allocate_frame() << 12 | PAGE_PRESENT | PAGE_WRITABLE;
-    memset((void*)PAGE_TABLE_VIRTUAL_ADDRESS(page_table, pdd, pdp), 0, 4096);
+    memset((void *)PDP_VIRTUAL_ADDRESS(pdp), 0, 4096);
+  }
+  if (((page_table_entry_t *)PDP_VIRTUAL_ADDRESS(pdp))[pdd] == 0) {
+    ((page_table_entry_t *)PDP_VIRTUAL_ADDRESS(pdp))[pdd] =
+        allocate_frame() << 12 | PAGE_PRESENT | PAGE_WRITABLE;
+    memset((void *)PDD_VIRTUAL_ADDRESS(pdd, pdp), 0, 4096);
+  }
+  if (((page_table_entry_t *)PDD_VIRTUAL_ADDRESS(pdd, pdp))[page_table] == 0) {
+    ((page_table_entry_t *)PDD_VIRTUAL_ADDRESS(pdd, pdp))[page_table] =
+        allocate_frame() << 12 | PAGE_PRESENT | PAGE_WRITABLE;
+    memset((void *)PAGE_TABLE_VIRTUAL_ADDRESS(page_table, pdd, pdp), 0, 4096);
   }
   return ((page_table_entry_t *)PAGE_TABLE_VIRTUAL_ADDRESS(page_table, pdd,
                                                            pdp)) +
@@ -55,7 +57,7 @@ void unmap_page(u64_t page_index) {
 
 void *map_physical_address(void *address, size_t size) {
   u64_t pages = (size + 4095) / 4096;
-  void *ptr = malloc(pages * 4096); 
+  void *ptr = malloc(pages * 4096);
   u64_t frame_index = ((u64_t)address) / 4096;
   u64_t page_index = ((u64_t)ptr) / 4096;
   reserve_frames(frame_index, frame_index + pages - 1);

--- a/kernel/arch/x86_64/kernel/paging/paging.c
+++ b/kernel/arch/x86_64/kernel/paging/paging.c
@@ -2,17 +2,17 @@
 #include <paging/frames.h>
 #include <strings.h>
 
-page_table_entry_t* init_page_table_0_0(u16_t page_table_index,
+page_table_entry_t *init_page_table_0_0(u16_t page_table_index,
                                         page_table_entry_t base) {
-  page_table_entry_t* page_table = allocate_frame() * 4096;
+  page_table_entry_t *page_table = allocate_frame() * 4096;
   page_table_entry_t physical_address = base;
   for (int i = 0; i < 512; i++, physical_address += 4096) {
     page_table[i] = physical_address;
   }
   return page_table;
 }
-page_table_entry_t* init_pdd_0_0() {
-  page_table_entry_t* pdd_0_0 = allocate_frame() * 4096;
+page_table_entry_t *init_pdd_0_0() {
+  page_table_entry_t *pdd_0_0 = allocate_frame() * 4096;
   page_table_entry_t base = PAGE_PRESENT | PAGE_WRITABLE;
   u16_t i;
   // identity map the first 64 megabytes
@@ -21,26 +21,20 @@ page_table_entry_t* init_pdd_0_0() {
                  PAGE_PRESENT | PAGE_WRITABLE;
     base += 4096 * 512;
   }
-  // put the rest of the page tables in empty so they can be allocated later
-  for (; i < 512; i++) {
-    page_table_entry_t* empty_page_table = (page_table_entry_t*)(allocate_frame() * 4096);
-    memset(empty_page_table, 0, 4096);
-    pdd_0_0[i] = (u64_t)empty_page_table | PAGE_PRESENT | PAGE_WRITABLE;
-  }
   return pdd_0_0;
 }
-page_table_entry_t* init_pdp0() {
-  page_table_entry_t* pdp0 = allocate_frame() * 4096;
+page_table_entry_t *init_pdp0() {
+  page_table_entry_t *pdp0 = allocate_frame() * 4096;
   memset(pdp0, 0, 4096);
   pdp0[0] = (page_table_entry_t)init_pdd_0_0() | PAGE_PRESENT | PAGE_WRITABLE;
   return pdp0;
 }
 void init_pml4() {
-  page_table_entry_t* pml4 = allocate_frame() * 4096;
+  page_table_entry_t *pml4 = allocate_frame() * 4096;
   memset(pml4, 0, 4096);
   pml4[256] = (page_table_entry_t)init_pdp0() | PAGE_PRESENT | PAGE_WRITABLE;
   // recursive mapping of page tables makes them accessible at a fixed virtual
   // address
   pml4[511] = ((u64_t) & (pml4[0])) | PAGE_PRESENT | PAGE_WRITABLE;
-  __asm__("movq %0, %%cr3" : : "a"(pml4[511]));  // put it in cr4
+  __asm__("movq %0, %%cr3" : : "a"(pml4[511])); // put it in cr4
 }


### PR DESCRIPTION
There used to be no checks when mapping pages about weather the page tables actually existed or not. This was why the page table initialisation code had to allocate a lot of memory for the first gigabyte of page tables. 
A better solution is to allocate frames for the page tables whenever map_page is called on a page with no page table. This also allows mapping of pages outside the kernel heap. This is now how the page tables are initialised.