### PR TITLE
fixed most of the warnings produced during compilation

### DIFF
--- a/kernel/arch/x86_64/kernel/drivers/pci/configuration_space.c
+++ b/kernel/arch/x86_64/kernel/drivers/pci/configuration_space.c
@@ -10,23 +10,22 @@ u32_t pci_read_configuration_register(u8_t bus, u8_t dev, u8_t func,
   u32_t pci_address =
       (bus_32 << 16) | (dev_32 << 11) | (func_32 << 8) |
       (register_offset & 0xFC) |
-      (u32_t)0x80000000;  // bus = pci bus, dev = device, func = device
-                          // function, offset = offset into the pci
-                          // configuration space, 0x80000000 = control bit set
-  outl(pci_address, 0xCF8);  // give the address to the pci controller
+      (u32_t)0x80000000;    // bus = pci bus, dev = device, func = device
+                            // function, offset = offset into the pci
+                            // configuration space, 0x80000000 = control bit set
+  outl(pci_address, 0xCF8); // give the address to the pci controller
   io_delay();
-  return inl(0xCFC);  // read back the result
+  return inl(0xCFC); // read back the result
 }
 u32_t pci_write_configuration_register(u8_t bus, u8_t dev, u8_t func,
                                        u8_t register_offset, u32_t data) {
   u32_t bus_32 = (u32_t)bus;
   u32_t dev_32 = (u32_t)dev;
-  u32_t func_32 = (u32_t)func;
 
   u32_t address = (bus_32 << 16) | (dev_32 << 11) | (func << 8) |
                   (register_offset & 0xFC) | (u32_t)0x80000000;
-  outl(address, 0xCF8);  // put the address in
+  outl(address, 0xCF8); // put the address in
   io_delay();
-  outl(data, 0xCFC);  // actually write the data
-  return inl(0xCFC);  // return the new contents of the register
+  outl(data, 0xCFC); // actually write the data
+  return inl(0xCFC); // return the new contents of the register
 }

--- a/kernel/arch/x86_64/kernel/multiboot/mbi.c
+++ b/kernel/arch/x86_64/kernel/multiboot/mbi.c
@@ -78,11 +78,12 @@ void scan_mbi() {
     reserve_frames(module_tag->start >> 12, (module_tag->end + 4095) / 4096);
   }
   mbi_ptr = (u64_t)map_physical_address((void *)multiboot_data_ptr, mbi_size);
-    for (int i = 0; i < number_of_modules; i++) {
+  for (int i = 0; i < number_of_modules; i++) {
     mbi_boot_module_tag_t *module_tag =
         (mbi_boot_module_tag_t *)(mbi_ptr + module_offsets[i]);
     u32_t size = module_tag->end - module_tag->start;
-    void *module_data = map_physical_address((void *)module_tag->start, size);
+    void *module_data =
+        map_physical_address((void *)(u64_t)module_tag->start, size);
     int name_size = strlen(module_tag->name);
     boot_module_t *module = malloc(sizeof(boot_module_t) + name_size + 1);
     strcpy(module->name, module_tag->name);

--- a/kernel/arch/x86_64/kernel/paging/frames.c
+++ b/kernel/arch/x86_64/kernel/paging/frames.c
@@ -106,7 +106,7 @@ void reserve_frames(u64_t start_index, u64_t end_index) {
     memory_block_t *block = &(free_memory.blocks[i]);
     u64_t block_start = (u64_t)block->base / 4096;
     u64_t block_end = block_start + block->length / 4096;
-    if (block_start * 4096 != block->base) {
+  if (block_start * 4096 != (u64_t)block->base) {
       fatal_error("Block base is not aligned");
     }
     if ((block_end - block_start) * 4096 != block->length) {

--- a/kernel/arch/x86_64/kernel/paging/paging.c
+++ b/kernel/arch/x86_64/kernel/paging/paging.c
@@ -4,7 +4,8 @@
 
 page_table_entry_t *init_page_table_0_0(u16_t page_table_index,
                                         page_table_entry_t base) {
-  page_table_entry_t *page_table = allocate_frame() * 4096;
+  page_table_entry_t *page_table =
+      (page_table_entry_t *)(allocate_frame() * 4096);
   page_table_entry_t physical_address = base;
   for (int i = 0; i < 512; i++, physical_address += 4096) {
     page_table[i] = physical_address;
@@ -12,7 +13,7 @@ page_table_entry_t *init_page_table_0_0(u16_t page_table_index,
   return page_table;
 }
 page_table_entry_t *init_pdd_0_0() {
-  page_table_entry_t *pdd_0_0 = allocate_frame() * 4096;
+  page_table_entry_t *pdd_0_0 = (page_table_entry_t *)(allocate_frame() * 4096);
   page_table_entry_t base = PAGE_PRESENT | PAGE_WRITABLE;
   u16_t i;
   // identity map the first 64 megabytes
@@ -26,13 +27,13 @@ page_table_entry_t *init_pdd_0_0() {
   return pdd_0_0;
 }
 page_table_entry_t *init_pdp0() {
-  page_table_entry_t *pdp0 = allocate_frame() * 4096;
+  page_table_entry_t *pdp0 = (page_table_entry_t *)(allocate_frame() * 4096);
   memset(pdp0, 0, 4096);
   pdp0[0] = (page_table_entry_t)init_pdd_0_0() | PAGE_PRESENT | PAGE_WRITABLE;
   return pdp0;
 }
 void init_pml4() {
-  page_table_entry_t *pml4 = allocate_frame() * 4096;
+  page_table_entry_t *pml4 = (page_table_entry_t *)(allocate_frame() * 4096);
   memset(pml4, 0, 4096);
   pml4[256] = (page_table_entry_t)init_pdp0() | PAGE_PRESENT | PAGE_WRITABLE;
   // recursive mapping of page tables makes them accessible at a fixed virtual

--- a/kernel/arch/x86_64/kernel/thread/thread.c
+++ b/kernel/arch/x86_64/kernel/thread/thread.c
@@ -18,13 +18,13 @@ int create_thread(thread_t *thread, void (*start)(void *), void *arg,
   }
   memset(task, 0, sizeof(task_state));
   task->name = name;
-  task->registers.rip = start;
-  task->registers.rflags = 0x200;  // Enable external interrupts
-  task->registers.rsp = stack;
+  task->registers.rip = (u64_t)start;
+  task->registers.rflags = 0x200; // Enable external interrupts
+  task->registers.rsp = (u64_t)stack;
   void *cr3;
   __asm__("mov %%cr3, %0" : "=a"(cr3));
-  task->registers.cr3 = cr3;
-  task->registers.rdi = arg;
+  task->registers.cr3 = (u64_t)cr3;
+  task->registers.rdi = (u64_t)arg;
   register_task_state(task);
   *thread = task->id;
   return 0;

--- a/kernel/fs/initramfs/initramfs.c
+++ b/kernel/fs/initramfs/initramfs.c
@@ -1,7 +1,7 @@
 #include <fs/initramfs.h>
 #include <strings.h>
 
-static inline size_t octal_to_binary(unsigned char *octal, size_t size) {
+static inline size_t octal_to_binary(const unsigned char *octal, size_t size) {
   size_t result = 0;
   for (size_t i = 0; i < size; i++) {
     result *= 8;
@@ -11,7 +11,7 @@ static inline size_t octal_to_binary(unsigned char *octal, size_t size) {
 }
 
 size_t initramfs_read(const unsigned char *initramfs, size_t initramfs_size,
-                      const char *file_name, const char **data) {
+                      const char *file_name, const unsigned char **data) {
   // Preliminary checks: is this a valid tar file?
   if (initramfs_size < 512) {
     // Too small to be a tar file

--- a/kernel/fs/vfs/directory.c
+++ b/kernel/fs/vfs/directory.c
@@ -11,7 +11,6 @@ file_t *virtual_directory_mkdir(file_t *file, const char *name) {
   directory->get_first_child = &virtual_directory_list;
   directory->mkdir = &virtual_directory_mkdir;
   if (file->data) {
-    int i = 0;
     file_t *tmp = (file_t *)file->data;
     while (tmp->next) {
       tmp = tmp->next;

--- a/kernel/include/error.h
+++ b/kernel/include/error.h
@@ -1,7 +1,7 @@
 #ifndef _ERROR_H
 #define _ERROR_H
 
-void fatal_error(const char* message);
+void _Noreturn fatal_error(const char* message);
 
 void kill_all();
 

--- a/kernel/include/fs/initramfs.h
+++ b/kernel/include/fs/initramfs.h
@@ -4,6 +4,6 @@
 #include <stdint.h>
 
 // Gets the contents of the specified file in the initramfs, returning the size or 0 if the file could not be found, and putting a pointer to the data in data.
-size_t initramfs_read(const unsigned char* initramfs, const size_t initramfs_size, const char* file_name, const char** data);
+size_t initramfs_read(const unsigned char* initramfs, const size_t initramfs_size, const char* file_name, const unsigned char** data);
 
 #endif

--- a/kernel/include/strings.h
+++ b/kernel/include/strings.h
@@ -4,8 +4,8 @@
 #include <stdint.h>
 
 void *memset(void *s, u8_t value, size_t size);
-void *memcpy(void *src, void *dst, size_t size);
-int memcmp(void *str1, void *str2, size_t size);
+void *memcpy(void * dst, const void * src, size_t size);
+int memcmp(const void *str1, const void *str2, size_t size);
 
 int strlen(const char *str);
 int strcpy(char *dest, const char *src);

--- a/kernel/kernel/error/error_screen.c
+++ b/kernel/kernel/error/error_screen.c
@@ -7,7 +7,7 @@ static display_pixel background = {
 static display_pixel character_foreground = {
     .red = 0x00, .green = 0x00, .blue = 0x00, .alpha = 0x00};
 
-void fatal_error(const char* message) {
+void _Noreturn fatal_error(const char *message) {
   kill_all();
   video_mode vidmode = *get_video_mode();
   for (int x = 0; x < vidmode.width; x++) {
@@ -16,7 +16,6 @@ void fatal_error(const char* message) {
     }
   }
   int columns = vidmode.width / get_character_width();
-  int rows = vidmode.height / get_character_height();
   int start_x = columns / 2 - 3;
   char error[6] = "Error!";
   for (int i = 0; i < 6; i++) {

--- a/kernel/kernel/main.c
+++ b/kernel/kernel/main.c
@@ -11,7 +11,7 @@
 void thread_start(void *arg) {
   // Find the init.conf file
   boot_module_t *module;
-  const char *init_conf = 0;
+  const unsigned char *init_conf = 0;
   size_t init_conf_size = 0;
   for (int i = 0; (module = get_boot_module(i)); i++) {
     init_conf_size =
@@ -23,7 +23,7 @@ void thread_start(void *arg) {
   if (init_conf) {
     puts("Found init.conf:");
     for (size_t i = 0; i < init_conf_size; i++) {
-      putchar(init_conf[i]);
+      putchar((char)(init_conf[i]));
     }
     putchar('\n');
   }

--- a/kernel/kernel/memory/memops.c
+++ b/kernel/kernel/memory/memops.c
@@ -7,7 +7,7 @@ void *calloc(size_t number, size_t size) {
   return memory;
 }
 
-int memcmp(void *a, void *b, size_t size) {
+int memcmp(const void *a, const void *b, size_t size) {
   const char *a_ptr = (const char *)a;
   const char *b_ptr = (const char *)b;
   for (int i = 0; i < size; i++) {


### PR DESCRIPTION
There used to be a lot of warnings produced when running make. most of these were simple 'integer to pointer convertion' warnings, which can be fixed very easily. 
There still are some warnings, but they are much harder to fix, and may require refactoring.