### PR TITLE
Allocate page function

### DIFF
--- a/kernel/arch/x86_64/include/page_tables.h
+++ b/kernel/arch/x86_64/include/page_tables.h
@@ -1,17 +1,12 @@
 #ifndef _PAGE_TABLES_H
 #define _PAGE_TABLES_H
 
+#include <paging/constants.h>
 #include <stdint.h>
 
 typedef u64_t page_table_entry_t;
 
 typedef u64_t page_table_t[512] __attribute__((aligned(4096)));
-
-#define PAGE_PRESENT (1 << 0)
-#define PAGE_WRITABLE (1 << 1)
-#define PAGE_USER (1 << 2)
-#define PAGE_WRITE_THROUGH_CACHE (1 << 3)
-#define PAGE_CACHE_DISABLE (1 << 4)
 
 void init_pml4();
 

--- a/kernel/arch/x86_64/include/paging/alloc.h
+++ b/kernel/arch/x86_64/include/paging/alloc.h
@@ -1,0 +1,19 @@
+#ifndef _PAGING_ALLOC_H
+#define _PAGING_ALLOC_H  
+
+#include <stdint.h>
+#include <page_tables.h>
+#include <paging/frames.h>
+
+static inline void allocate_pages(const void* address, u64_t pages, page_table_entry_t flags) {
+  for (u64_t i = 0; i < pages; i ++) {
+    map_page(allocate_frame(), (u64_t)address / 4096 + i, flags | PAGE_PRESENT);
+  }
+}
+static inline void free_pages(const void* address, u64_t pages) {
+  for (u64_t i = 0; i < pages; i ++) {
+    unmap_page((u64_t)address / 4096 + i);
+  } 
+}
+
+#endif

--- a/kernel/arch/x86_64/include/paging/constants.h
+++ b/kernel/arch/x86_64/include/paging/constants.h
@@ -1,0 +1,12 @@
+#ifndef _PAGING_CONSTANTS_H
+#define _PAGING_CONSTANTS_H
+
+#define PAGE_PRESENT (1 << 0)
+#define PAGE_WRITABLE (1 << 1)
+#define PAGE_USER (1 << 2)
+#define PAGE_WRITE_THROUGH_CACHE (1 << 3)
+#define PAGE_CACHE_DISABLE (1 << 4)
+
+#define PAGE_SIZE 4096
+
+#endif

--- a/kernel/arch/x86_64/kernel/paging/malloc/free.c
+++ b/kernel/arch/x86_64/kernel/paging/malloc/free.c
@@ -1,5 +1,6 @@
 #include <error.h>
 #include <page_tables.h>
+#include <paging/alloc.h>
 #include <paging/frames.h>
 
 #include "blocks.h"
@@ -18,8 +19,5 @@ void free(void *ptr) {
   create_block(
       (memblock_t){.start = working_ptr, .end = working_ptr + memblock_size});
   clean_blocks();
-  for (u64_t address = (u64_t)working_ptr;
-       address < (u64_t)working_ptr + memblock_size; address += 4096) {
-    unmap_page(address / 4096);
-  }
+  free_pages(working_ptr, memblock_size / 4096);
 }


### PR DESCRIPTION
The only way of easily allocating memory used to be malloc. This, however, does not allow selecting where to allocate the memory. 
This adds a new allocate_pages function, and corresponding free_pages function. These allow selection of where to allocate the memory, and how many pages to allocate.