### PR TITLE
Task state segment

### DIFF
--- a/kernel/arch/x86_64/include/gdt.h
+++ b/kernel/arch/x86_64/include/gdt.h
@@ -1,6 +1,7 @@
 #ifndef _GDT_H
 #define _GDT_H
 
+#define GDT_SYSTEM_TYPE(X) ((X & 0xF) << 40)
 #define GDT_CONFORMING(X) ((X & 1) << 42)
 #define GDT_EXEC(X) ((X & 1) << 43)
 #define GDT_TYPE(X) ((X & 1) << 44)

--- a/kernel/arch/x86_64/include/tss.h
+++ b/kernel/arch/x86_64/include/tss.h
@@ -1,0 +1,24 @@
+#ifndef _TSS_H
+#define _TSS_H  
+
+#include <stdint.h>
+
+typedef struct __attribute__((__packed__)) {
+  u32_t reserved0;
+  void* rsp0;
+  void* rsp1;
+  void* rsp2;
+  u32_t reserved1[2];
+  void* ist1;
+  void* ist2;
+  void* ist3;
+  void* ist4;
+  void* ist5;
+  void* ist6;
+  void* ist7;
+  u32_t reserved2[2];
+  u16_t reserved3;
+  u16_t io_port_base_offset;
+} tss_t;
+
+#endif

--- a/kernel/arch/x86_64/include/tss.h
+++ b/kernel/arch/x86_64/include/tss.h
@@ -21,4 +21,6 @@ typedef struct __attribute__((__packed__)) {
   u16_t io_port_base_offset;
 } tss_t;
 
+void setup_tss();
+
 #endif

--- a/kernel/arch/x86_64/init/finale.S
+++ b/kernel/arch/x86_64/init/finale.S
@@ -26,6 +26,26 @@ movw %ax, %fs
 movw %ax, %gs
 movw %ax, %ss
 
+// Set up the tss]
+movabsq $gdt_tss_descriptor, %rdi
+movw $104, (%rdi)
+movabsq $tss, %rsi
+movw %si, 2(%rdi)
+movl 4(%rdi), %eax
+shrq $16, %rsi
+orb %sil, %al
+shrq $8, %rsi
+xorl %edx, %edx
+movb %sil, %dl
+shll $24, %edx
+orl %edx, %eax
+movl %eax, 4(%rdi)
+shrq $8, %rsi
+movl %esi, 8(%rdi)
+
+movw $24, %ax
+ltr %ax
+
 /*Set the new stack*/
 movabsq $stack_top, %rsp
 

--- a/kernel/arch/x86_64/init/gdt.S
+++ b/kernel/arch/x86_64/init/gdt.S
@@ -26,4 +26,9 @@ gdt64_ptr:
 gdt64:
 .quad 0 /*required null descriptor*/
 .quad GDT_PRESENT(1) | GDT_LONG(1) | GDT_TYPE(1) | GDT_EXEC(1) /*64 bit segment*/
+.quad 0 /*User mode code segment*/
+.globl gdt_tss_descriptor
+gdt_tss_descriptor:
+.quad GDT_SYSTEM_TYPE(9) | GDT_PRESENT(1) /*Tss lower half*/
+.quad 0 /*Tss second half*/
 gdt64_end:

--- a/kernel/arch/x86_64/kernel/Makefile
+++ b/kernel/arch/x86_64/kernel/Makefile
@@ -11,7 +11,7 @@ STEPS+=drivers/pci/configuration_space.o
 STEPS+=drivers/serial/query.o drivers/serial/configuration.o drivers/serial/out.o
 STEPS+=multiboot/mbi.o
 STEPS+=error/kill.o
-STEPS+=task/state.o
+STEPS+=task/state.o task/tss.o
 STEPS+=thread/thread.o
 STEPS+=drivers/rtc/timer/handler.o drivers/rtc/timer/init.o
 

--- a/kernel/arch/x86_64/kernel/init/main.c
+++ b/kernel/arch/x86_64/kernel/init/main.c
@@ -1,6 +1,7 @@
 #include <interrupts.h>
 #include <pics.h>
 #include <stdio.h>
+#include <tss.h>
 
 extern volatile u64_t number_of_debug_interrupts;
 
@@ -63,13 +64,13 @@ void init_interrupts() {
       STANDARD_INTERRUPT((u64_t)&security_exception_handler);
   idt_pointer.limit = sizeof(idt) - 1;
   idt_pointer.ptr = (u64_t)idt;
-  __asm__ volatile ("movabsq %0, %%rax;"
-          "lidt (%%rax);"
-          :
-          : "i"(&idt_pointer)
-          : "rax");
+  __asm__ volatile("movabsq %0, %%rax;"
+                   "lidt (%%rax);"
+                   :
+                   : "i"(&idt_pointer)
+                   : "rax");
   u64_t preserve = number_of_debug_interrupts;
-  __asm__ volatile ("int %0" : : "i"(INTERRUPT_DEBUG));
+  __asm__ volatile("int %0" : : "i"(INTERRUPT_DEBUG));
   if (number_of_debug_interrupts <= preserve) {
     puts("interrupt didn't run");
   die:
@@ -84,6 +85,7 @@ void arch_init() {
   scan_mbi();
   init_interrupts();
   configure_pics();
+  setup_tss();
   return;
 }
 

--- a/kernel/arch/x86_64/kernel/task/tss.S
+++ b/kernel/arch/x86_64/kernel/task/tss.S
@@ -1,0 +1,7 @@
+.file "tss.S"
+
+.bss
+
+.globl tss
+tss:
+.fill 104

--- a/kernel/arch/x86_64/kernel/task/tss.S
+++ b/kernel/arch/x86_64/kernel/task/tss.S
@@ -1,7 +1,0 @@
-.file "tss.S"
-
-.bss
-
-.globl tss
-tss:
-.fill 104

--- a/kernel/arch/x86_64/kernel/task/tss.c
+++ b/kernel/arch/x86_64/kernel/task/tss.c
@@ -1,0 +1,3 @@
+#include <tss.h>
+
+tss_t tss;

--- a/kernel/arch/x86_64/kernel/task/tss.c
+++ b/kernel/arch/x86_64/kernel/task/tss.c
@@ -5,6 +5,6 @@ tss_t tss;
 u8_t rsp0[8192];
 
 void setup_tss() {
-  tss.rsp0 = rsp0;
+  tss.rsp0 = rsp0 + 8192;
   tss.io_port_base_offset = 104;
 }

--- a/kernel/arch/x86_64/kernel/task/tss.c
+++ b/kernel/arch/x86_64/kernel/task/tss.c
@@ -1,3 +1,10 @@
 #include <tss.h>
 
 tss_t tss;
+
+u8_t rsp0[8192];
+
+void setup_tss() {
+  tss.rsp0 = rsp0;
+  tss.io_port_base_offset = 104;
+}


### PR DESCRIPTION
The task state segment defines several fields required for user mode operations. 
The most notable of these is rsp0. rsp0 is the stack pointer for kernel mode interrupts. Without this, the first interrupt in user mode would cause the system to crash.