### PR TITLE
Restructured the gdt to allow for syscalls

### DIFF
--- a/kernel/arch/x86_64/init/gdt.S
+++ b/kernel/arch/x86_64/init/gdt.S
@@ -25,12 +25,13 @@ gdt64_ptr:
 
 gdt64:
 .quad 0 /*required null descriptor*/
-.quad GDT_PRESENT(1) | GDT_LONG(1) | GDT_TYPE(1) | GDT_EXEC(1) /*64 bit kernel segment*/
-.quad GDT_PRESENT(1) | GDT_LONG(1) | GDT_TYPE(1) | GDT_PRIV(3) | GDT_EXEC(1) /*User mode code segment*/
+.quad GDT_PRESENT(1) | GDT_LONG(1) | GDT_TYPE(1) | GDT_EXEC(1) /*64 bit code segment*/
+.quad GDT_PRESENT(1) | GDT_TYPE(1) | GDT_WRITABLE(1) /*Syscall kernel mode stack segment*/
 .globl gdt_tss_descriptor
 gdt_tss_descriptor:
 .quad GDT_SYSTEM_TYPE(9) | GDT_PRESENT(1) /*Tss lower half*/
 .quad 0 /*Tss second half*/
 
 .quad GDT_PRESENT(1) | GDT_TYPE(1) | GDT_PRIV(3) | GDT_WRITABLE(1) /*User mode stack segment*/
+.quad GDT_PRESENT(1) | GDT_LONG(1) | GDT_TYPE(1) | GDT_PRIV(3) | GDT_EXEC(1) /*User mode code segment*/
 gdt64_end:

--- a/kernel/arch/x86_64/kernel/thread/thread.c
+++ b/kernel/arch/x86_64/kernel/thread/thread.c
@@ -26,7 +26,7 @@ int create_thread(thread_t *thread, void (*start)(void *), void *arg,
   task->registers.cr3 = (u64_t)cr3;
   task->registers.rdi = (u64_t)arg;
   if (user_mode) {
-    task->registers.cs = 16 | 3; // User mode (16) | 3 (destination privilege level)
+    task->registers.cs = 48 | 3; // User mode (48) | 3 (destination privilege level)
     task->registers.ss = 40 | 3; // Stack segment (40) | 3 (user mode)
   } else {
     task->registers.cs = 8;


### PR DESCRIPTION
The syscall/sysret instructions require a specific layout of the stack. 
- The kernel mode code segment is 8 bytes before the kernel mode stack segment.
- The user mode code segment is 8 bytes past the user mode stack segment.
This change satisfies these requirements.