### PR TITLE
Message passing in syscalls

### DIFF
--- a/kernel/arch/x86_64/include/ptrrange.h
+++ b/kernel/arch/x86_64/include/ptrrange.h
@@ -1,0 +1,9 @@
+#ifndef _PTRRANGE_H
+#define _PTRRANGE_H  
+
+#include <stdint.h>
+
+#define IS_KERNEL_MODE_POINTER(PTR)  (((u64_t)PTR & (1ULL << 63ULL)) != 0)
+#define IS_USER_MODE_POINTER(PTR)  (!IS_KERNEL_MODE_POINTER(PTR))
+
+#endif

--- a/kernel/arch/x86_64/include/task/gs.h
+++ b/kernel/arch/x86_64/include/task/gs.h
@@ -1,0 +1,9 @@
+#ifndef _TASK_GS_H
+#define _TASK_GS_H  
+
+typedef struct __attribute__((__packed__)) {
+  void* kernel_stack;
+  void* user_stack;
+} gs_context_t;
+
+#endif

--- a/kernel/arch/x86_64/include/task/registers.h
+++ b/kernel/arch/x86_64/include/task/registers.h
@@ -3,11 +3,14 @@
 
 #include <stdint.h>
 
+#include <task/gs.h>
+
 typedef struct __attribute__((__packed__)) {
   u64_t rip, rflags, rax, rbp, rbx, rcx, rdi, rdx, rsi, rsp, r8, r9, r10, r11,
       r12, r13, r14, r15;  // general-purpose + rip and rflags
   u64_t cr3;               // page table
   u64_t cs, ss;
+  gs_context_t gs_context;
 } register_state;
 
 #endif

--- a/kernel/arch/x86_64/include/tss.h
+++ b/kernel/arch/x86_64/include/tss.h
@@ -21,6 +21,4 @@ typedef struct __attribute__((__packed__)) {
   u16_t io_port_base_offset;
 } tss_t;
 
-void setup_tss();
-
 #endif

--- a/kernel/arch/x86_64/kernel/Makefile
+++ b/kernel/arch/x86_64/kernel/Makefile
@@ -14,6 +14,7 @@ STEPS+=error/kill.o
 STEPS+=task/state.o task/tss.o
 STEPS+=thread/thread.o
 STEPS+=drivers/rtc/timer/handler.o drivers/rtc/timer/init.o
+STEPS+=syscall/syscall_entry.o syscall/syscall_setup.o
 
 Micos.build: $(STEPS)
 	$(LD) $(LDFLAGS) $^ -o $@

--- a/kernel/arch/x86_64/kernel/init/main.c
+++ b/kernel/arch/x86_64/kernel/init/main.c
@@ -1,7 +1,6 @@
 #include <interrupts.h>
 #include <pics.h>
 #include <stdio.h>
-#include <tss.h>
 
 extern volatile u64_t number_of_debug_interrupts;
 
@@ -87,7 +86,6 @@ void arch_init() {
   scan_mbi();
   init_interrupts();
   configure_pics();
-  setup_tss();
   initialize_syscalls();
   return;
 }

--- a/kernel/arch/x86_64/kernel/init/main.c
+++ b/kernel/arch/x86_64/kernel/init/main.c
@@ -81,11 +81,14 @@ void init_interrupts() {
 
 void scan_mbi();
 
+void initialize_syscalls();
+
 void arch_init() {
   scan_mbi();
   init_interrupts();
   configure_pics();
   setup_tss();
+  initialize_syscalls();
   return;
 }
 

--- a/kernel/arch/x86_64/kernel/syscall/syscall_entry.S
+++ b/kernel/arch/x86_64/kernel/syscall/syscall_entry.S
@@ -4,5 +4,17 @@
 
 .globl syscall_entrypoint
 syscall_entrypoint:
+swapgs
+movq %rsp, %gs:8 /*Save user mode stack*/
+movq %gs:0, %rsp /*Get kernel mode stack*/
 sti
+pushq %rcx
+pushq %r11
+movq %r10, %rcx /*Move arg3 to where the compiler expects it*/
+callq syscall_handler
+popq %r11
+popq %rcx
+cli
+movq %gs:8, %rsp
+swapgs
 sysretq

--- a/kernel/arch/x86_64/kernel/syscall/syscall_entry.S
+++ b/kernel/arch/x86_64/kernel/syscall/syscall_entry.S
@@ -1,0 +1,8 @@
+.file "syscall_entry.S"
+
+.text
+
+.globl syscall_entrypoint
+syscall_entrypoint:
+sti
+sysretq

--- a/kernel/arch/x86_64/kernel/syscall/syscall_setup.S
+++ b/kernel/arch/x86_64/kernel/syscall/syscall_setup.S
@@ -11,7 +11,7 @@ rdmsr
 orl $1, %eax
 wrmsr /*Enable syscall instructions*/
 xorl %edx, %edx
-orl $32, %edx /*User mode selectors*/
+orl $(32 | 3), %edx /*User mode selectors*/
 shll $16, %edx
 orl $8, %edx /*Kernel mode selectors*/
 xorl %eax, %eax

--- a/kernel/arch/x86_64/kernel/syscall/syscall_setup.S
+++ b/kernel/arch/x86_64/kernel/syscall/syscall_setup.S
@@ -1,0 +1,31 @@
+.file "syscall_setup.S"
+
+.text
+
+.globl initialize_syscalls
+initialize_syscalls:
+pushq %rbp
+movq %rsp, %rbp
+movl $0xC0000080, %ecx /*EFER*/
+rdmsr
+orl $1, %eax
+wrmsr /*Enable syscall instructions*/
+xorl %edx, %edx
+orl $32, %edx /*User mode selectors*/
+shll $16, %edx
+orl $8, %edx /*Kernel mode selectors*/
+xorl %eax, %eax
+movl $0xC0000081, %ecx /*STAR*/
+wrmsr /*Set sysret and syscall segment selectors*/
+movabsq $syscall_entrypoint, %rdi
+movl %edi, %eax /*Low 32 bits of entrypoint*/
+shrq $32, %rdi
+movl %edi, %edx /*High 32 bits of entrypoint*/
+movl $0xC0000082, %ecx /*LSTAR*/
+wrmsr
+xorl %eax, %eax
+orl $(1 << 9), %eax /*Mask interrupts*/
+movl $0xC0000084, %ecx /*SFMASK*/
+wrmsr
+popq %rbp
+retq

--- a/kernel/arch/x86_64/kernel/task/state.S
+++ b/kernel/arch/x86_64/kernel/task/state.S
@@ -44,6 +44,15 @@ retq
 .globl restore_register_state
 restore_register_state: /*Register parameter rdi: register_state* state*/
 movq %rdi, %rbp
+movabsq $tss, %rdi
+movq 168(%rbp), %rdx
+movq %rdx, 4(%rdi) /*Put the kernel stack in the tss for the cpu*/
+leaq 168(%rbp), %rdi
+movl %edi, %eax
+shrq $32, %rdi
+movl %edi, %edx
+movl $0xC0000102, %ecx /*Kernel gs base*/
+wrmsr /*Set kernel gs base for syscall*/
 pushq 160(%rbp) /*ss*/
 pushq 72 (%rbp) /*rsp*/
 pushq 8 (%rbp) /*rflags*/

--- a/kernel/arch/x86_64/kernel/task/tss.c
+++ b/kernel/arch/x86_64/kernel/task/tss.c
@@ -1,10 +1,3 @@
 #include <tss.h>
 
 tss_t tss;
-
-u8_t rsp0[8192];
-
-void setup_tss() {
-  tss.rsp0 = rsp0 + 8192;
-  tss.io_port_base_offset = 104;
-}

--- a/kernel/arch/x86_64/kernel/thread/thread.c
+++ b/kernel/arch/x86_64/kernel/thread/thread.c
@@ -17,10 +17,13 @@ int create_thread(thread_t *thread, void (*start)(void *), void *arg,
     return 1;
   }
   memset(task, 0, sizeof(task_state));
+  if (!user_mode) {
+    task->registers.rsp = (u64_t)stack;
+  }
+  task->registers.gs_context.kernel_stack = stack;
   task->name = name;
   task->registers.rip = (u64_t)start;
   task->registers.rflags = 0x200; // Enable external interrupts
-  task->registers.rsp = (u64_t)stack;
   void *cr3;
   __asm__("mov %%cr3, %0" : "=a"(cr3));
   task->registers.cr3 = (u64_t)cr3;

--- a/kernel/include/syscalls.h
+++ b/kernel/include/syscalls.h
@@ -1,0 +1,15 @@
+#ifndef _SYSCALLS_H
+#define _SYSCALLS_H
+
+typedef enum {
+  SYSCALL_MESSAGE_POST = 0,
+  SYSCALL_MESSAGE_PENDING = 1,
+  SYSCALL_MESSAGE_GET = 2
+} syscall_code_t;
+
+typedef union {
+  u16_t u16;
+  message_delivery_status message_status;
+} syscall_result_t;
+
+#endif

--- a/kernel/kernel/Makefile
+++ b/kernel/kernel/Makefile
@@ -8,6 +8,7 @@ STEPS+=task/registry.o
 STEPS+=strings/strops.o
 STEPS+=memory/memops.o
 STEPS+=stack/protector.o
+STEPS+=syscall/syscall_handler.o
 
 Micos.build: $(STEPS)
 	$(LD) $(LDFLAGS) $^ -o $@

--- a/kernel/kernel/main.c
+++ b/kernel/kernel/main.c
@@ -53,7 +53,14 @@ void thread_start(void *arg) {
   } else {
     fatal_error("No init service found");
   }
-  wait();
+  while (true) {
+    message_t message;
+    message_get(&message);
+    puts("Got message with opcode:");
+    putdec64(message.header.opcode);
+    puts("From thread:");
+    putdec64(message.header.from);
+  }
 }
 
 void main(void) {

--- a/kernel/kernel/syscall/syscall_handler.c
+++ b/kernel/kernel/syscall/syscall_handler.c
@@ -1,19 +1,32 @@
+#include <message.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <syscalls.h>
 
-void syscall_handler(u32_t code, ...) {
-    va_list varargs;
-    va_start(varargs, code);
-    switch (code) {
-        case 101: {
-            // Debug trace
-            puts("Debug trace");
-            break;
-        }
-        default:
-          puts("Unknown syscall number:");
-          putdec64(code);
-    }
-    va_end(varargs);
+syscall_result_t syscall_handler(syscall_code_t code, ...) {
+  va_list varargs;
+  va_start(varargs, code);
+  syscall_result_t result = {0};
+  switch (code) {
+      case SYSCALL_MESSAGE_POST: {
+        result.message_status =
+            message_post(va_arg(varargs, message_header_t),
+                         va_arg(varargs, message_payload_t));
+        break;
+      }
+  case SYSCALL_MESSAGE_PENDING: {
+    result.u16 = message_pending();
+    break;
+  }
+  case SYSCALL_MESSAGE_GET: {
+    message_get(va_arg(varargs, message_t*));
+    break;
+  }
+  default:
+    puts("Unknown syscall number:");
+    putdec64(code);
+  }
+  va_end(varargs);
+  return result;
 }

--- a/kernel/kernel/syscall/syscall_handler.c
+++ b/kernel/kernel/syscall/syscall_handler.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+
+void syscall_handler(u32_t code, ...) {
+    va_list varargs;
+    va_start(varargs, code);
+    switch (code) {
+        case 101: {
+            // Debug trace
+            puts("Debug trace");
+            break;
+        }
+        default:
+          puts("Unknown syscall number:");
+          putdec64(code);
+    }
+    va_end(varargs);
+}

--- a/kernel/kernel/syscall/syscall_handler.c
+++ b/kernel/kernel/syscall/syscall_handler.c
@@ -1,4 +1,5 @@
 #include <message.h>
+#include <ptrrange.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -20,7 +21,12 @@ syscall_result_t syscall_handler(syscall_code_t code, ...) {
     break;
   }
   case SYSCALL_MESSAGE_GET: {
-    message_get(va_arg(varargs, message_t*));
+    message_t* destination_pointer = va_arg(varargs, message_t*);
+    if (IS_USER_MODE_POINTER(destination_pointer)) { // Don't overwrite kernel memory
+    message_get(destination_pointer);
+    }else {
+      puts("The application just tried to compromise the kernel!");
+    }
     break;
   }
   default:

--- a/services/init/init.S
+++ b/services/init/init.S
@@ -4,4 +4,6 @@
 
 .globl _start
 _start:
+movq $101, %rdi
+syscall /*Debug trace*/
 1: jmp 1b

--- a/services/init/init.S
+++ b/services/init/init.S
@@ -4,6 +4,11 @@
 
 .globl _start
 _start:
-movq $101, %rdi
-syscall /*Debug trace*/
+movl $0, %edi /*Post message*/
+orl $72, %esi /*Opcode*/
+shlq $16, %rsi
+orl $1, %esi /*To*/
+shlq $16, %rsi
+xorl %edx, %edx /*Payload*/
+syscall /*Post message*/
 1: jmp 1b

--- a/services/init/init.S
+++ b/services/init/init.S
@@ -11,4 +11,7 @@ orl $1, %esi /*To*/
 shlq $16, %rsi
 xorl %edx, %edx /*Payload*/
 syscall /*Post message*/
+movl $2, %edi /*Get message*/
+movabsq $0xFFFF800000000000, %rsi /*Kernel pointer, out of bounds*/
+syscall /*Try to overwrite the kernel*/
 1: jmp 1b


### PR DESCRIPTION
There used to be only one syscall: debug trace. 
This removes the debug trace syscall, and adds three more for the message passing functions message_post, message_pending and message_get. 
