### PR TITLE
Load elf binary

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -4,7 +4,7 @@ LD=ld.lld
 LDFLAGS=-T arch/$(ARCH)/linker.ld
 
 OUTDIR=arch/$(ARCH)/build
-STEPS=arch/$(ARCH)/Micos.build core/Micos.build drivers/Micos.build fonts/Micos.build fs/Micos.build
+STEPS=arch/$(ARCH)/Micos.build core/Micos.build drivers/Micos.build fonts/Micos.build fs/Micos.build exec/Micos.build
 TARGET=$(OUTDIR)/Micos
 
 CC=clang

--- a/kernel/arch/x86_64/include/exec/arch_elf.h
+++ b/kernel/arch/x86_64/include/exec/arch_elf.h
@@ -1,0 +1,14 @@
+#ifndef _EXEC_ARCH_ELF_H
+#define _EXEC_ARCH_ELF_H  
+
+// 64 bit = 2 in the ELF header
+#define ELF_NATIVE_BITNESS  2
+// Little endian = 1 in the ELF header
+#define ELF_NATIVE_ENDIANNESS  1
+// AMD64 = 0x3E in the ELF header
+#define ELF_NATIVE_INSTRUCTION_SET  0x3E
+
+// Set which ELF structure to use
+#define ELF_USE_ELF64  1
+
+#endif

--- a/kernel/exec/Makefile
+++ b/kernel/exec/Makefile
@@ -1,0 +1,11 @@
+STEPS:=elf.o
+
+Micos.build: $(STEPS)
+	$(LD) $(LDFLAGS) $^ -o $@
+
+%.o: %.c
+	echo "$(CC) $(BASEDIR)/$@"
+	$(CC) $(CFLAGS) -c $^ -o $@
+
+clean:
+	rm -f $(STEPS)

--- a/kernel/exec/Makefile
+++ b/kernel/exec/Makefile
@@ -1,4 +1,4 @@
-STEPS:=elf.o
+STEPS:=exec.o elf.o
 
 Micos.build: $(STEPS)
 	$(LD) $(LDFLAGS) $^ -o $@

--- a/kernel/exec/elf.c
+++ b/kernel/exec/elf.c
@@ -1,0 +1,1 @@
+#include <exec/elf.h>

--- a/kernel/exec/elf.c
+++ b/kernel/exec/elf.c
@@ -1,4 +1,6 @@
 #include <exec/elf.h>
+#include <paging/alloc.h>
+#include <ptrrange.h>
 #include <strings.h>
 
 bool elf_matches(const unsigned char *file, size_t size) {
@@ -20,11 +22,45 @@ bool elf_matches(const unsigned char *file, size_t size) {
   if (header->common_header.instruction_set != ELF_NATIVE_INSTRUCTION_SET) {
     return false;
   }
+  // Yes, but is it an executable?
+  if (header->common_header.type != ELF_EXECUTABLE) {
+    return false;
+  }
   // Yes.
   return true;
 }
 
 exec_entrypoint elf_load(const unsigned char *file, size_t size) {
-  // TODO
-  return 0;
+  elf_header_t *header = (elf_header_t *)file;
+  const unsigned char *program_header_base = file + header->program_header_offset;
+  for (u16_t i = 0; i < header->num_program_header_entries; i++) {
+    elf_program_header_entry_t *program_header_entry =
+        (elf_program_header_entry_t *)(program_header_base +
+                                       i * header->program_header_entry_size);
+    if (program_header_entry->type == ELF_LOADABLE) {
+      if (!IS_KERNEL_MODE_POINTER(program_header_entry->virtual_address) &&
+          !IS_KERNEL_MODE_POINTER(
+              ((unsigned char *)program_header_entry->virtual_address) +
+              program_header_entry->size_in_memory)) {
+        if (program_header_entry->file_offset +
+                program_header_entry->size_in_file <
+            size) {
+          void *section_address = program_header_entry->virtual_address;
+          allocate_pages(section_address,
+                         (program_header_entry->size_in_memory + PAGE_SIZE - 1) / PAGE_SIZE,
+                         PAGE_WRITABLE | PAGE_USER);
+          memcpy(section_address, file + program_header_entry->file_offset,
+                 program_header_entry->size_in_file);
+                 if (program_header_entry->size_in_memory > program_header_entry->size_in_file) {
+          memset((unsigned char *)section_address +
+                     program_header_entry->size_in_file,
+                 0,
+                 program_header_entry->size_in_memory -
+                     program_header_entry->size_in_file);
+                 }
+        }
+      }
+    }
+  }
+  return header->entrypoint;
 }

--- a/kernel/exec/elf.c
+++ b/kernel/exec/elf.c
@@ -1,1 +1,30 @@
 #include <exec/elf.h>
+#include <strings.h>
+
+bool elf_matches(const unsigned char *file, size_t size) {
+  // Is it an ELF file?
+  if (size < sizeof(elf_header_t)) {
+    return false;
+  }
+  if (memcmp(file, "\177ELF", 4) != 0) {
+    return false;
+  }
+  // Yes, but is it native?
+  elf_header_t *header = (elf_header_t *)file;
+  if (header->common_header.bitness != ELF_NATIVE_BITNESS) {
+    return false;
+  }
+  if (header->common_header.endianness != ELF_NATIVE_ENDIANNESS) {
+    return false;
+  }
+  if (header->common_header.instruction_set != ELF_NATIVE_INSTRUCTION_SET) {
+    return false;
+  }
+  // Yes.
+  return true;
+}
+
+exec_entrypoint elf_load(const unsigned char *file, size_t size) {
+  // TODO
+  return 0;
+}

--- a/kernel/exec/exec.c
+++ b/kernel/exec/exec.c
@@ -1,0 +1,16 @@
+#include <exec.h>
+#include <exec/elf.h>
+#include <exec/format.h>
+
+static exec_format_t exec_formats[] = {ELF_FORMAT};
+static int num_exec_formats = sizeof(exec_formats) / sizeof(exec_format_t);
+
+exec_status exec_load(const unsigned char* file, size_t size, exec_entrypoint* entrypoint) {
+  for (int i = 0; i < num_exec_formats; i ++) {
+      if (exec_formats[i].matches(file, size)) {
+        *entrypoint = exec_formats[i].load(file, size);
+        return EXEC_SUCCESS;
+      }
+  }
+  return EXEC_FORMAT_ERROR;
+  }

--- a/kernel/include/exec.h
+++ b/kernel/include/exec.h
@@ -1,0 +1,11 @@
+#ifndef _EXEC_H
+#define _EXEC_H
+
+#include <exec/format.h>
+
+typedef enum { EXEC_SUCCESS, EXEC_FORMAT_ERROR } exec_status;
+
+exec_status exec_load(const unsigned char* file, size_t size,
+                      exec_entrypoint* entrypoint);
+
+#endif

--- a/kernel/include/exec/elf.h
+++ b/kernel/include/exec/elf.h
@@ -18,6 +18,13 @@ typedef struct __attribute__((__packed__)) {
   u32_t elf_version;
 } elf_common_header_t;
 
+typedef enum {
+  ELF_RELOCATABLE = 1,
+  ELF_EXECUTABLE = 2,
+  ELF_SHARED = 3,
+  ELF_CORE_DUMP = 4
+} elf_file_type;
+
 #ifdef ELF_USE_ELF64
 typedef struct __attribute__((__packed__)) {
   elf_common_header_t common_header;
@@ -32,6 +39,24 @@ typedef struct __attribute__((__packed__)) {
   u16_t num_section_header_entries;
   u16_t section_name_section_index;
 } elf_header_t;
+
+typedef struct __attribute__((__packed__)) {
+  u32_t type; // 0 = null, 1 = loadable, 2 = dynamic, 3 = interpreter
+  u32_t flags;
+  u64_t file_offset;
+  void* virtual_address;
+  u64_t undefined;
+  u64_t size_in_file;
+  u64_t size_in_memory;
+  u64_t required_alignment;
+} elf_program_header_entry_t;
+
+typedef enum {
+  ELF_NULL = 0,
+  ELF_LOADABLE = 1,
+  ELF_DYNAMIC = 2,
+  ELF_INTERPRETER = 3
+} elf_program_header_entry_type;
 #else
 #ifdef ELF_USE_ELF32
 #error ELF32 structure not currently supported

--- a/kernel/include/exec/elf.h
+++ b/kernel/include/exec/elf.h
@@ -40,9 +40,9 @@ typedef struct __attribute__((__packed__)) {
 #endif
 #endif
 
-bool elf_matches(unsigned char* file, size_t size);
+bool elf_matches(const unsigned char* file, size_t size);
 
-exec_entrypoint elf_load(unsigned char* file, size_t size);
+exec_entrypoint elf_load(const unsigned char* file, size_t size);
 
 #define ELF_FORMAT  ((exec_format_t){.matches = elf_matches, .load = elf_load})
 

--- a/kernel/include/exec/elf.h
+++ b/kernel/include/exec/elf.h
@@ -1,0 +1,49 @@
+#ifndef _EXEC_ELF_H
+#define _ELF_EXEC_H  
+
+#include <exec/arch_elf.h>
+#include <exec/format.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct __attribute__((__packed__)) {
+  unsigned char magic[4]; // \177, 'E', 'L', 'F'
+  u8_t bitness; // 1 = 32 bit, 2 = 64 bit
+  u8_t endianness; // 1 = little endian, 2 = big endian
+  u8_t header_version;
+  u8_t abi;
+  u64_t padding; // Unused
+  u16_t type; // 1 = relocatable, 2 = executable, 3 = shared, 4 = core dump
+  u16_t instruction_set;
+  u32_t elf_version;
+} elf_common_header_t;
+
+#ifdef ELF_USE_ELF64
+typedef struct __attribute__((__packed__)) {
+  elf_common_header_t common_header;
+  void* entrypoint;
+  u64_t program_header_offset;
+  u64_t section_header_offset;
+  u32_t flags;
+  u16_t header_size;
+  u16_t program_header_entry_size;
+  u16_t num_program_header_entries;
+  u16_t section_header_entry_size;
+  u16_t num_section_header_entries;
+  u16_t section_name_section_index;
+} elf_header_t;
+#else
+#ifdef ELF_USE_ELF32
+#error ELF32 structure not currently supported
+#else
+#error Either ELF_USE_ELF32 or ELF_USE_ELF64 must be defined
+#endif
+#endif
+
+bool elf_matches(unsigned char* file, size_t size);
+
+exec_entrypoint elf_load(unsigned char* file, size_t size);
+
+#define ELF_FORMAT  ((exec_format_t){.matches = elf_matches, .load = elf_load})
+
+#endif

--- a/kernel/include/exec/format.h
+++ b/kernel/include/exec/format.h
@@ -1,0 +1,15 @@
+#ifndef _EXEC_FORMAT_H
+#define _EXEC_FORMAT_H  
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef void (*exec_entrypoint)(void);
+
+typedef struct {
+  bool (*matches)(unsigned char* file, size_t size);
+  // Returns the start address
+  exec_entrypoint (*load)(unsigned char* file, size_t size);
+} exec_format_t;
+
+#endif

--- a/kernel/include/exec/format.h
+++ b/kernel/include/exec/format.h
@@ -7,9 +7,9 @@
 typedef void (*exec_entrypoint)(void);
 
 typedef struct {
-  bool (*matches)(unsigned char* file, size_t size);
+  bool (*matches)(const unsigned char* file, size_t size);
   // Returns the start address
-  exec_entrypoint (*load)(unsigned char* file, size_t size);
+  exec_entrypoint (*load)(const unsigned char* file, size_t size);
 } exec_format_t;
 
 #endif

--- a/services/init/Makefile
+++ b/services/init/Makefile
@@ -15,9 +15,7 @@ STEPS:=init.o
 
 build/init: $(STEPS)
 	mkdir -p build
-	$(LD) $(LDFLAGS) $^ -o $@.elf
-	objcopy -O binary $@.elf $@
-	rm $@.elf
+	$(LD) $(LDFLAGS) $^ -o $@
 
 %.o: %.S
 	echo "$(AS) $(BASEDIR)/$@"

--- a/services/init/init.S
+++ b/services/init/init.S
@@ -5,7 +5,7 @@
 .globl _start
 _start:
 movl $0, %edi /*Post message*/
-orl $72, %esi /*Opcode*/
+orl test_thing, %esi /*Opcode*/
 shlq $16, %rsi
 orl $1, %esi /*To*/
 shlq $16, %rsi
@@ -15,3 +15,8 @@ movl $2, %edi /*Get message*/
 movabsq $0xFFFF800000000000, %rsi /*Kernel pointer, out of bounds*/
 syscall /*Try to overwrite the kernel*/
 1: jmp 1b
+
+.bss
+
+test_thing:
+.fill 8

--- a/services/init/linker.ld
+++ b/services/init/linker.ld
@@ -1,18 +1,18 @@
 SECTIONS {
-    . = 0x1000;
-    .text : {
+    . = 0x20000;
+    .text ALIGN(4k) : {
         *(.txt)
         *(.txt.*)
     }
-    .data : {
+    .data ALIGN(4k) : {
         *(.data)
         *(.data.*)
     }
-    .rodata : {
+    .rodata ALIGN(4k) : {
         *(.rodata)
         *(.rodata.*)
     }
-    .bss : {
+    .bss ALIGN(4k) : {
         *(.bss)
         *(.bss.*)
         *(common)


### PR DESCRIPTION
The kernel used to have no real way of loading a binary into user space. The method that was used before was a simple memcpy of a flat binary file.

This adds an ELF loader and a more well defined exec system.