### PR TITLE
Save gs bases

### DIFF
--- a/debugging/helper.gdb
+++ b/debugging/helper.gdb
@@ -1,0 +1,13 @@
+# Helper functions for better debugging with gdb
+
+define trace-function
+if $arg0
+    break $arg0
+    commands
+        continue
+        end
+    end
+end
+document trace-function
+    Print a message every time a function is called
+end

--- a/debugging/qemu-headless.gdb
+++ b/debugging/qemu-headless.gdb
@@ -1,2 +1,3 @@
 file build/Micos
+source debugging/helper.gdb
 target remote | qemu-system-x86_64 -S -gdb stdio -cdrom build/Micos.iso -display none

--- a/debugging/qemu.gdb
+++ b/debugging/qemu.gdb
@@ -1,2 +1,3 @@
 file build/Micos
+source debugging/helper.gdb
 target remote | qemu-system-x86_64 -S -gdb stdio -cdrom build/Micos.iso

--- a/kernel/arch/x86_64/include/task/registers.h
+++ b/kernel/arch/x86_64/include/task/registers.h
@@ -7,10 +7,11 @@
 
 typedef struct __attribute__((__packed__)) {
   u64_t rip, rflags, rax, rbp, rbx, rcx, rdi, rdx, rsi, rsp, r8, r9, r10, r11,
-      r12, r13, r14, r15;  // general-purpose + rip and rflags
-  u64_t cr3;               // page table
-  u64_t cs, ss;
-  gs_context_t gs_context;
+      r12, r13, r14, r15;        // general-purpose + rip and rflags
+  u64_t cr3;                     // page table
+  u64_t cs, ss;                  // Code and stack segments
+  u64_t active_gs, alternate_gs; // Used for swapgs
+  gs_context_t gs_context;       // Data for use with syscall
 } register_state;
 
 #endif

--- a/kernel/arch/x86_64/kernel/task/state.S
+++ b/kernel/arch/x86_64/kernel/task/state.S
@@ -39,20 +39,41 @@ movq 40(%rsp), %rax
 movq %rax, 160(%rbp) /*ss*/
 movq 48(%rsp), %rax
 movq %rax, 152(%rbp) /*cs*/
+
+movq $32, %rdx
+movl $0xC0000101, %ecx /*Active gs base*/
+rdmsr /*Get it*/
+shlq $32, %rdx
+orq %rax, %rdx
+movq %rdx, 168(%rbp) /*Active gs base*/
+
+movl $0xC0000102, %ecx /*Alternate gs base*/
+rdmsr /*Get it*/
+shlq $32, %rdx
+orq %rax, %rdx
+movq %rdx, 176(%rbp) /*Alternate gs base*/
 retq
 
 .globl restore_register_state
 restore_register_state: /*Register parameter rdi: register_state* state*/
 movq %rdi, %rbp
+
 movabsq $tss, %rdi
-movq 168(%rbp), %rdx
+movq 184(%rbp), %rdx
 movq %rdx, 4(%rdi) /*Put the kernel stack in the tss for the cpu*/
-leaq 168(%rbp), %rdi
+
+movq 168(%rbp), %rdi
 movl %edi, %eax
 shrq $32, %rdi
 movl %edi, %edx
-movl $0xC0000102, %ecx /*Kernel gs base*/
-wrmsr /*Set kernel gs base for syscall*/
+movl $0xC0000101, %ecx /*Active gs base*/
+wrmsr /*Set active gs base*/
+movq 176(%rbp), %rdi
+movl %edi, %eax
+shrq $32, %rdi
+movl %edi, %edx
+movl $0xC0000102, %ecx /*Alternate gs base*/
+wrmsr /*Set alternate gs base for syscall*/
 pushq 160(%rbp) /*ss*/
 pushq 72 (%rbp) /*rsp*/
 pushq 8 (%rbp) /*rflags*/

--- a/kernel/arch/x86_64/kernel/thread/thread.c
+++ b/kernel/arch/x86_64/kernel/thread/thread.c
@@ -21,6 +21,7 @@ int create_thread(thread_t *thread, void (*start)(void *), void *arg,
     task->registers.rsp = (u64_t)stack;
   }
   task->registers.gs_context.kernel_stack = stack;
+  task->registers.alternate_gs = (u64_t)&task->registers.gs_context;
   task->name = name;
   task->registers.rip = (u64_t)start;
   task->registers.rflags = 0x200; // Enable external interrupts

--- a/services/init/init.S
+++ b/services/init/init.S
@@ -14,7 +14,10 @@ syscall /*Post message*/
 movl $2, %edi /*Get message*/
 movabsq $0xFFFF800000000000, %rsi /*Kernel pointer, out of bounds*/
 syscall /*Try to overwrite the kernel*/
-1: jmp 1b
+1:
+movl $1, %edi
+syscall /*message_pending*/
+jmp 1b
 
 .bss
 


### PR DESCRIPTION
The gs base saving logic used to just save the base of the kernel data into the alternate (kernel) gs base MSR. This would not have worked if the program was preempted in the kernel, as the gs base would not be expected to be in the alternate base register.

This changes the logic to save both of the base registers in their own dedicated slots in the register state, to allow for preempting in system calls or interrupts.