### PR TITLE
Allow alignment of task state structure

### DIFF
--- a/kernel/arch/x86_64/kernel/drivers/rtc/timer/handler.S
+++ b/kernel/arch/x86_64/kernel/drivers/rtc/timer/handler.S
@@ -45,7 +45,7 @@ pushq %r8
 pushq %r9
 pushq %r10
 pushq %r11
-callq get_current_task_state
+callq get_current_register_state
 popq %r11
 popq %r10
 popq %r9
@@ -59,7 +59,7 @@ popq %rax
 movq (%rbp), %rbp
 callq save_register_state
 
-callq get_next_task_state
+callq get_next_register_state
 movq %rax, %rdi
 callq restore_register_state
 

--- a/kernel/include/task/registry.h
+++ b/kernel/include/task/registry.h
@@ -3,8 +3,8 @@
 
 #include <task/state.h>
 
-task_state* get_current_task_state();
+task_state* get_current_task_state(void);
 void register_task_state(task_state* task);
-task_state* get_next_task_state(task_state* current);
+task_state* get_next_task_state(void);
 
 #endif

--- a/kernel/include/task/state.h
+++ b/kernel/include/task/state.h
@@ -5,7 +5,7 @@
 #include <lock.h>
 #include <message.h>
 
-typedef struct __attribute__((__packed__)) {
+typedef struct {
   register_state registers;
   const char* name;
   u16_t id;


### PR DESCRIPTION
The task_state structure used to have the packed attribute to allow assembly code to access the register state from it. This meant that the compiler gave warnings about potentially unaligned pointers for the message lock.

This change allows the compiler to align the members of the task state structure freely, by adding specific functions to get the register state for the current and next tasks.