### PR TITLE
Move compiler configuration to root

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -14,19 +14,19 @@ include arch/$(ARCH)/Make.properties
 all: $(TARGET)
 
 $(TARGET): $(STEPS)
-	@echo "build $(BASEDIR)/$@"
-	@mkdir -p $(OUTDIR)
-	@$(LD) $(LDFLAGS) $^ -o $@
-	@echo "kernel file saved to $(shell pwd)/$(TARGET)"
-	@rm $(STEPS)
+	echo "build $(BASEDIR)/$@"
+	mkdir -p $(OUTDIR)
+	$(LD) $(LDFLAGS) $^ -o $@
+	echo "kernel file saved to $(shell pwd)/$(TARGET)"
+	rm $(STEPS)
 
 %/Micos.build: %
-	@"$(MAKE)" -s -C "$^" Micos.build BASEDIR="$(BASEDIR)/$^" ARCH="$(ARCH)" LD="$(LD)" AS="$(AS)" CC="$(CC)" ASFLAGS="$(ASFLAGS)" LDFLAGS="" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)"
+	"$(MAKE)" -s -C "$^" Micos.build BASEDIR="$(BASEDIR)/$^" LDFLAGS=""
 
 clean: $(subst Micos.build,clean,$(STEPS))
-	@echo "clean $(BASEDIR)/$(TARGET)"
-	@rm -f $(TARGET)
+	echo "clean $(BASEDIR)/$(TARGET)"
+	rm -f $(TARGET)
 
 %/clean: %
-	@echo "clean $(BASEDIR)/$^"
-	@"$(MAKE)" -s -C $^ clean BASEDIR="$(BASEDIR)/$^"
+	echo "clean $(BASEDIR)/$^"
+	"$(MAKE)" -s -C $^ clean BASEDIR="$(BASEDIR)/$^"

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,22 +1,15 @@
-ARCH?=x86_64
-
-LD=ld.lld
 LDFLAGS=-T arch/$(ARCH)/linker.ld
 
+export CPPFLAGS:=-I "$(CURDIR)/include" -I "$(CURDIR)/arch/$(ARCH)/include"
+
 OUTDIR=arch/$(ARCH)/build
+
 STEPS=arch/$(ARCH)/Micos.build core/Micos.build drivers/Micos.build fonts/Micos.build fs/Micos.build exec/Micos.build
 TARGET=$(OUTDIR)/Micos
 
-CC=clang
-AS=clang
+CFLAGS+=-mcmodel=large -fstack-protector-strong
 
-INCLUDEARGS=-I "$(CURDIR)/include" -I "$(CURDIR)/arch/$(ARCH)/include"
-
-AFLAGS=-target $(ARCH)-unknown-none-gnu -ffreestanding $(INCLUDEARGS)
-CFLAGS=-target $(ARCH)-unknown-none-gnu -ffreestanding -O2 -std=c11 $(INCLUDEARGS) -Wall -mcmodel=large -fstack-protector-strong -fno-omit-frame-pointer -g
-EXTERNALLDFLAGS=-relocatable
-
-include $(CURDIR)/arch/$(ARCH)/Make.properties
+include arch/$(ARCH)/Make.properties
 
 all: $(TARGET)
 
@@ -28,7 +21,7 @@ $(TARGET): $(STEPS)
 	@rm $(STEPS)
 
 %/Micos.build: %
-	@"$(MAKE)" -s -C "$^" Micos.build BASEDIR="$(BASEDIR)/$^" ARCH="$(ARCH)" LD="$(LD)" AS="$(AS)" CC="$(CC)" AFLAGS="$(AFLAGS)" LDFLAGS="$(EXTERNALLDFLAGS)" CFLAGS="$(CFLAGS)"
+	@"$(MAKE)" -s -C "$^" Micos.build BASEDIR="$(BASEDIR)/$^" ARCH="$(ARCH)" LD="$(LD)" AS="$(AS)" CC="$(CC)" ASFLAGS="$(ASFLAGS)" LDFLAGS="" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)"
 
 clean: $(subst Micos.build,clean,$(STEPS))
 	@echo "clean $(BASEDIR)/$(TARGET)"

--- a/kernel/arch/x86_64/Makefile
+++ b/kernel/arch/x86_64/Makefile
@@ -1,11 +1,11 @@
 STEPS=head/Micos.build init/Micos.build kernel/Micos.build
 
 Micos.build: $(STEPS)
-	$(LD) $(LDFLAGS) $^ -o $@
+	$(LD) $(LDFLAGS) -relocatable $^ -o $@
 	rm $(STEPS)
 
 %/Micos.build: %
-	"$(MAKE)" -s -C "$^" Micos.build BASEDIR="$(BASEDIR)/$^" ARCH="$(ARCH)" LD="$(LD)" AS="$(AS)" CC="$(CC)" AFLAGS="$(AFLAGS)" LDFLAGS="$(LDFLAGS)" CFLAGS="$(CFLAGS)"
+	"$(MAKE)" -s -C "$^" Micos.build BASEDIR="$(BASEDIR)/$^"
 
 clean: $(subst Micos.build,clean,$(STEPS))
 

--- a/kernel/arch/x86_64/head/Makefile
+++ b/kernel/arch/x86_64/head/Makefile
@@ -1,11 +1,11 @@
 STEPS=head.o
 
 Micos.build: $(STEPS)
-	$(LD) $(LDFLAGS) $^ -o $@
+	$(LD) $(LDFLAGS) -relocatable $^ -o $@
 
 %.o: %.S
 	echo "$(AS) $(BASEDIR)/$@"
-	$(AS) $(AFLAGS) -c $^ -o $@
+	$(AS) $(ASFLAGS) $(CPPFLAGS) -c $^ -o $@
 
 clean:
 	rm -f $(STEPS)

--- a/kernel/arch/x86_64/init/Makefile
+++ b/kernel/arch/x86_64/init/Makefile
@@ -1,11 +1,11 @@
 STEPS=entry.o init.o gdt.o paging.o err.o long.o multiboot.o finale.o
 
 Micos.build: $(STEPS)
-	$(LD) $(LDFLAGS) $^ -o $@
+	$(LD) $(LDFLAGS) -relocatable $^ -o $@
 
 %.o: %.S
 	echo "$(AS) $(BASEDIR)/$@"
-	$(AS) $(AFLAGS) -c $^ -o $@
+	$(AS) $(ASFLAGS) $(CPPFLAGS) -c $^ -o $@
 
 clean:
 	rm -f $(STEPS)

--- a/kernel/arch/x86_64/kernel/Makefile
+++ b/kernel/arch/x86_64/kernel/Makefile
@@ -17,15 +17,15 @@ STEPS+=drivers/rtc/timer/handler.o drivers/rtc/timer/init.o
 STEPS+=syscall/syscall_entry.o syscall/syscall_setup.o
 
 Micos.build: $(STEPS)
-	$(LD) $(LDFLAGS) $^ -o $@
+	$(LD) $(LDFLAGS) -relocatable $^ -o $@
 
 %.o: %.S
 	echo "$(AS) $(BASEDIR)/$@"
-	$(AS) $(AFLAGS) -c $^ -o $@
+	$(AS) $(ASFLAGS) $(CPPFLAGS) -c $^ -o $@
 
 %.o: %.c
 	echo "$(CC) $(BASEDIR)/$@"
-	$(CC) $(CFLAGS) -c $^ -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c $^ -o $@
 
 clean:
 	rm -f $(STEPS)

--- a/kernel/core/Makefile
+++ b/kernel/core/Makefile
@@ -8,11 +8,11 @@ STEPS+=stack/protector.o
 STEPS+=syscall/syscall_handler.o
 
 Micos.build: $(STEPS)
-	$(LD) $(LDFLAGS) $^ -o $@
+	$(LD) $(LDFLAGS) -relocatable $^ -o $@
 
 %.o: %.c
 	echo "$(CC) $(BASEDIR)/$@"
-	$(CC) $(CFLAGS) -c $^ -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c $^ -o $@
 
 clean:
 	rm -f $(STEPS)

--- a/kernel/drivers/Makefile
+++ b/kernel/drivers/Makefile
@@ -5,11 +5,11 @@ STEPS+=pci/pci_init.o pci/pci_probe.o pci/pci_table.o
 STEPS+=console/console.o
 
 Micos.build: $(STEPS)
-	$(LD) $(LDFLAGS) $^ -o $@
+	$(LD) $(LDFLAGS) -relocatable $^ -o $@
 
 %.o: %.c
 	echo "$(CC) $(BASEDIR)/$@"
-	$(CC) $(CFLAGS) -c $^ -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c $^ -o $@
 
 clean:
 	rm -f $(STEPS)

--- a/kernel/exec/Makefile
+++ b/kernel/exec/Makefile
@@ -1,11 +1,11 @@
 STEPS:=exec.o elf.o
 
 Micos.build: $(STEPS)
-	$(LD) $(LDFLAGS) $^ -o $@
+	$(LD) $(LDFLAGS) -relocatable $^ -o $@
 
 %.o: %.c
 	echo "$(CC) $(BASEDIR)/$@"
-	$(CC) $(CFLAGS) -c $^ -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c $^ -o $@
 
 clean:
 	rm -f $(STEPS)

--- a/kernel/fonts/Makefile
+++ b/kernel/fonts/Makefile
@@ -1,15 +1,15 @@
 STEPS=font.o renderer/psf.o
 
 Micos.build: $(STEPS)
-	$(LD) $(LDFLAGS) $^ -o $@
+	$(LD) $(LDFLAGS) -relocatable $^ -o $@
 
 %.o: %.c
 	echo "$(CC) $(BASEDIR)/$@"
-	$(CC) $(CFLAGS) -c $^ -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c $^ -o $@
 
 %.o: %.s
 	echo "$(AS) $(BASEDIR)/$@"
-	$(AS) $(AFLAGS) -c $^ -o $@
+	$(AS) $(ASFLAGS) $(CPPFLAGS) -c $^ -o $@
 
 clean:
 	rm -f $(STEPS)

--- a/kernel/fs/Makefile
+++ b/kernel/fs/Makefile
@@ -2,11 +2,11 @@ STEPS:=vfs/vfs.o vfs/directory.o
 STEPS+=initramfs/initramfs.o
 
 Micos.build: $(STEPS)
-	$(LD) $(LDFLAGS) $^ -o $@
+	$(LD) $(LDFLAGS) -relocatable $^ -o $@
 
 %.o: %.c
 	echo "$(CC) $(BASEDIR)/$@"
-	$(CC) $(CFLAGS) -c $^ -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c $^ -o $@
 
 clean:
 	rm -f $(STEPS)

--- a/services/init/Makefile
+++ b/services/init/Makefile
@@ -1,14 +1,3 @@
-ARCH?=x86_64
-
-CC:=clang
-AS:=clang
-
-TARGET:=$(ARCH)-unknown-none-gnu
-
-CFLAGS:=-target $(TARGET) -ffreestanding
-AFLAGS:=-target $(TARGET) -ffreestanding
-
-LD:=ld.lld
 LDFLAGS:=-T linker.ld
 
 STEPS:=init.o
@@ -19,7 +8,7 @@ build/init: $(STEPS)
 
 %.o: %.S
 	echo "$(AS) $(BASEDIR)/$@"
-	$(AS) $(AFLAGS) -c $^ -o $@
+	$(AS) $(ASFLAGS) -c $^ -o $@
 
 clean:
 	rm -f $(STEPS)


### PR DESCRIPTION
When the kernel was the entire repository, it decided its own CC, AS, etc., which was fine. However, after it was moved into a subdirectory, it kept this for simplicity.

This moves the compiler configuration (CC, AS, etc.) into the root level Makefile, leaving all kernel specific details in the kernel subdirectory.